### PR TITLE
Retrieving data

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "test"
   ],
   "dependencies": {
+    "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
     "underscore": "~1.8.2"
   },

--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>rise-google-sheet Demo</title>
+
+  <script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
+  <link rel="import" href="rise-google-sheet.html">
+
+</head>
+<body unresolved>
+
+<rise-google-sheet id="googleSheet" key="1P5kJXEszMm-vNpaPeQ6I-rD9SGM_gqacIrHMOUrQx_I"></rise-google-sheet>
+
+<script>
+  (function () {
+    "use strict";
+
+    function webComponentsReady() {
+      window.removeEventListener("WebComponentsReady", webComponentsReady);
+
+      var googleSheet = document.getElementById("googleSheet");
+
+      googleSheet.addEventListener("rise-google-sheet-response", function (e) {
+        console.log(e.detail.cells);
+      });
+
+      googleSheet.addEventListener("rise-google-sheet-error", function (e) {
+        console.log(e.detail);
+      });
+
+      googleSheet.go();
+
+    }
+
+    window.addEventListener("WebComponentsReady", webComponentsReady);
+
+  })();
+</script>
+
+</body>
+</html>

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -1,4 +1,16 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-ajax/iron-ajax.html">
+
+<dom-module id="rise-google-sheet">
+  <template>
+    <iron-ajax id="sheet"
+               params='{"alt": "json"}'
+               handle-as="json"
+               on-response="_onSheetResponse"
+               on-error="_onSheetError">
+    </iron-ajax>
+  </template>
+</dom-module>
 
 <script>
   (function() {
@@ -6,6 +18,8 @@
     /* jshint newcap: false */
 
     "use strict";
+
+    var SCOPE = "https://spreadsheets.google.com/feeds";
 
     Polymer({
       is: "rise-google-sheet",
@@ -24,7 +38,63 @@
        */
 
       properties: {
-        // TODO: to come
+        /**
+         * The key of the spreadsheet. This can be found in the URL when viewing
+         * the document in Google Docs (e.g. docs.google.com/spreadsheet/ccc?key=<KEY>).
+         */
+        key: {
+          type: String,
+          value: ""
+        },
+
+        /**
+         * Tab within a spreadsheet. For example, the first tab in a spreadsheet
+         * would be `tab-id="1"`.
+         */
+        tabId: {
+          type: Number,
+          value: 1
+        },
+
+        /**
+         * Returns a list of cell data.
+         */
+        cells: {
+          type: Array,
+          value: function() { return []; },
+          readOnly: true,
+          notify: true
+        }
+      },
+
+      _prepareResponse: function (resp) {
+        var response = {};
+
+        response.cells = resp.feed.entry;
+
+        // TODO: provide meta data (title, authors, etc)?
+
+        return response;
+      },
+
+      _onSheetError: function(e, err) {
+        this.fire("rise-google-sheet-error", err.error.message);
+      },
+
+      _onSheetResponse: function(e, resp) {
+        var responseData;
+
+        // in case there are other instances of rise-google-sheet
+        e.stopPropagation();
+
+        if (resp && resp.response) {
+          responseData = this._prepareResponse(resp.response);
+
+          // use setter method to apply cells value because this property is read only
+          this._setCells(responseData.cells);
+
+          this.fire("rise-google-sheet-response", responseData);
+        }
       },
 
       /**
@@ -33,7 +103,10 @@
        * @method go
        */
       go: function() {
-        // TODO: logic to come
+        var url = SCOPE + "/cells/" + this.key + "/" +  this.tabId + "/public/full";
+
+        this.$.sheet.url = url;
+        this.$.sheet.generateRequest();
       }
 
     });

--- a/test/data/error.js
+++ b/test/data/error.js
@@ -1,0 +1,6 @@
+var errorData = {
+  "error": {
+    "message": "The request failed with status code: 400"
+  },
+  "request": {}
+};

--- a/test/data/sheet.js
+++ b/test/data/sheet.js
@@ -1,0 +1,281 @@
+var sheetData = {
+  "encoding": "UTF-8",
+  "feed": {
+    "author": [
+      {
+        "email": {
+          "$t": "stuartlees@risevision.com"
+        },
+        "name": {
+          "$t": "stuart.lees"
+        }
+      }
+    ],
+    "category": [
+      {
+        "scheme": "http://schemas.google.com/spreadsheets/2006",
+        "term": "http://schemas.google.com/spreadsheets/2006#cell"
+      }
+    ],
+    "entry": [
+      {
+        "category": [
+          {
+            "scheme": "http://schemas.google.com/spreadsheets/2006",
+            "term": "http://schemas.google.com/spreadsheets/2006#cell"
+          }
+        ],
+        "content": {
+          "$t": "Description",
+          "type": "text"
+        },
+        "gs$cell": {
+          "$t": "Description",
+          "col": "1",
+          "row": "1"
+        },
+        "id": {
+          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R1C1"
+        },
+        "link": [
+          {
+            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R1C1",
+            "rel": "self",
+            "type": "application/atom+xml"
+          }
+        ],
+        "title": {
+          "$t": "A1",
+          "type": "text"
+        },
+        "updated": {
+          "$t": "2015-05-19T20:37:34.428Z"
+        }
+      },
+      {
+        "category": [
+          {
+            "scheme": "http://schemas.google.com/spreadsheets/2006",
+            "term": "http://schemas.google.com/spreadsheets/2006#cell"
+          }
+        ],
+        "content": {
+          "$t": "Number",
+          "type": "text"
+        },
+        "gs$cell": {
+          "$t": "Number",
+          "col": "2",
+          "row": "1"
+        },
+        "id": {
+          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R1C2"
+        },
+        "link": [
+          {
+            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R1C2",
+            "rel": "self",
+            "type": "application/atom+xml"
+          }
+        ],
+        "title": {
+          "$t": "B1",
+          "type": "text"
+        },
+        "updated": {
+          "$t": "2015-05-19T20:37:34.428Z"
+        }
+      },
+      {
+        "category": [
+          {
+            "scheme": "http://schemas.google.com/spreadsheets/2006",
+            "term": "http://schemas.google.com/spreadsheets/2006#cell"
+          }
+        ],
+        "content": {
+          "$t": "Type",
+          "type": "text"
+        },
+        "gs$cell": {
+          "$t": "Type",
+          "col": "3",
+          "row": "1"
+        },
+        "id": {
+          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R1C3"
+        },
+        "link": [
+          {
+            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R1C3",
+            "rel": "self",
+            "type": "application/atom+xml"
+          }
+        ],
+        "title": {
+          "$t": "C1",
+          "type": "text"
+        },
+        "updated": {
+          "$t": "2015-05-19T20:37:34.428Z"
+        }
+      },
+      {
+        "category": [
+          {
+            "scheme": "http://schemas.google.com/spreadsheets/2006",
+            "term": "http://schemas.google.com/spreadsheets/2006#cell"
+          }
+        ],
+        "content": {
+          "$t": "Apple",
+          "type": "text"
+        },
+        "gs$cell": {
+          "$t": "Apple",
+          "col": "1",
+          "row": "2"
+        },
+        "id": {
+          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R2C1"
+        },
+        "link": [
+          {
+            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R2C1",
+            "rel": "self",
+            "type": "application/atom+xml"
+          }
+        ],
+        "title": {
+          "$t": "A2",
+          "type": "text"
+        },
+        "updated": {
+          "$t": "2015-05-19T20:37:34.428Z"
+        }
+      },
+      {
+        "category": [
+          {
+            "scheme": "http://schemas.google.com/spreadsheets/2006",
+            "term": "http://schemas.google.com/spreadsheets/2006#cell"
+          }
+        ],
+        "content": {
+          "$t": "123",
+          "type": "text"
+        },
+        "gs$cell": {
+          "$t": "123",
+          "col": "2",
+          "row": "2"
+        },
+        "id": {
+          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R2C2"
+        },
+        "link": [
+          {
+            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R2C2",
+            "rel": "self",
+            "type": "application/atom+xml"
+          }
+        ],
+        "title": {
+          "$t": "B2",
+          "type": "text"
+        },
+        "updated": {
+          "$t": "2015-05-19T20:37:34.428Z"
+        }
+      },
+      {
+        "category": [
+          {
+            "scheme": "http://schemas.google.com/spreadsheets/2006",
+            "term": "http://schemas.google.com/spreadsheets/2006#cell"
+          }
+        ],
+        "content": {
+          "$t": "Fruit",
+          "type": "text"
+        },
+        "gs$cell": {
+          "$t": "Fruit",
+          "col": "3",
+          "row": "2"
+        },
+        "id": {
+          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R2C3"
+        },
+        "link": [
+          {
+            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R2C3",
+            "rel": "self",
+            "type": "application/atom+xml"
+          }
+        ],
+        "title": {
+          "$t": "C2",
+          "type": "text"
+        },
+        "updated": {
+          "$t": "2015-05-19T20:37:34.428Z"
+        }
+      }
+    ],
+    "gs$colCount": {
+      "$t": "26"
+    },
+    "gs$rowCount": {
+      "$t": "1000"
+    },
+    "id": {
+      "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values"
+    },
+    "link": [
+      {
+        "href": "https://docs.google.com/spreadsheets/d/abc123/pubhtml",
+        "rel": "alternate",
+        "type": "application/atom+xml"
+      },
+      {
+        "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values",
+        "rel": "http://schemas.google.com/g/2005#feed",
+        "type": "application/atom+xml"
+      },
+      {
+        "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values",
+        "rel": "http://schemas.google.com/g/2005#post",
+        "type": "application/atom+xml"
+      },
+      {
+        "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/batch",
+        "rel": "http://schemas.google.com/g/2005#batch",
+        "type": "application/atom+xml"
+      },
+      {
+        "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values?alt=json",
+        "rel": "self",
+        "type": "application/atom+xml"
+      }
+    ],
+    "openSearch$startIndex": {
+      "$t": "1"
+    },
+    "openSearch$totalResults": {
+      "$t": "6"
+    },
+    "title": {
+      "$t": "Test Sheet",
+      "type": "text"
+    },
+    "updated": {
+      "$t": "2015-05-19T20:37:34.428Z"
+    },
+    "xmlns": "http://www.w3.org/2005/Atom",
+    "xmlns$batch": "http://schemas.google.com/gdata/batch",
+    "xmlns$gs": "http://schemas.google.com/spreadsheets/2006",
+    "xmlns$openSearch": "http://a9.com/-/spec/opensearchrss/1.0/"
+  },
+  "version": "1.0"
+};

--- a/test/rise-google-sheet-integration.html
+++ b/test/rise-google-sheet-integration.html
@@ -12,28 +12,40 @@
 </head>
 <body>
 
-<rise-google-sheet id="request"></rise-google-sheet>
+<rise-google-sheet id="request" key="abc123"></rise-google-sheet>
+
+<script src="data/sheet.js"></script>
 
 <script>
   suite("rise-google-sheet", function() {
-    var clock, responded, listener,
+    var clock, server, responseHandler,
       sheetRequest = document.querySelector("#request");
 
     // Runs for every suite.
     suiteSetup(function() {
+      server = sinon.fakeServer.create();
+      server.respondImmediately = true;
+
       clock = sinon.useFakeTimers();
     });
 
     suiteTeardown(function() {
+      server.restore();
       clock.restore();
     });
 
-    // Runs for every test.
-    setup(function() {
-      responded = false;
-    });
+    suite("request data", function() {
+      test("should return an Array of cell objects", function(done) {
+        responseHandler = function(response) {
+          assert.deepEqual(response.detail.cells, sheetData.feed.entry);
+          done();
+        };
 
-    // TODO: tests to come
+        sheetRequest.addEventListener("rise-google-sheet-response", responseHandler);
+        server.respondWith([200, {}, JSON.stringify(sheetData)]);
+        sheetRequest.go();
+      });
+    });
 
   });
 </script>

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -12,10 +12,13 @@
 </head>
 <body>
 
-<rise-google-sheet id="request"></rise-google-sheet>
+<rise-google-sheet id="request" key="abc123"></rise-google-sheet>
+
+<script src="data/sheet.js"></script>
+<script src="data/error.js"></script>
 
 <script>
-  suite("rise-google-sheet", function() {
+  suite("rise-google-sheet", function () {
     var clock, responded, listener,
       sheetRequest = document.querySelector("#request");
 
@@ -31,7 +34,61 @@
       responded = false;
     });
 
-    // TODO: tests to come
+    suite("_onSheetError", function () {
+      test("should fire rise-google-sheet-error if there is a problem with the Sheets request", function(done) {
+        listener = function(response) {
+          responded = true;
+
+          assert.isString(response.detail, "detail is a String");
+          assert.equal(response.detail, errorData.error.message, "detail value is the error message");
+
+          sheetRequest.removeEventListener("rise-google-sheet-error", listener);
+        };
+
+        sheetRequest.addEventListener("rise-google-sheet-error", listener);
+        sheetRequest._onSheetError({}, errorData);
+        assert.isTrue(responded);
+        done();
+      });
+    });
+
+    suite("_onSheetResponse", function () {
+      test("should fire rise-google-sheet-response and provide an Array of cell objects", function(done) {
+        var resp = {
+            "response": _.clone(sheetData)
+          },
+          e = {
+            "stopPropagation": function () {}
+          };
+
+        listener = function(response) {
+          responded = true;
+
+          assert.property(response.detail, "cells", "detail.cells property exists");
+          assert.isArray(response.detail.cells, "detail.cells is an Array");
+          assert.deepEqual(response.detail.cells, resp.response.feed.entry, "detail.cells value is correct");
+
+          sheetRequest.removeEventListener("rise-google-sheet-response", listener);
+        };
+
+        sheetRequest.addEventListener("rise-google-sheet-response", listener);
+        sheetRequest._onSheetResponse(e, resp);
+
+        assert.deepEqual(sheetRequest.cells, resp.response.feed.entry);
+        assert.isTrue(responded);
+        done();
+      });
+    });
+
+    suite("_prepareResponse", function() {
+      test("should return an Array of cell objects", function() {
+        var response = sheetRequest._prepareResponse(sheetData);
+
+        assert.property(response, "cells");
+        assert.isArray(response.cells);
+        assert.deepEqual(response.cells, sheetData.feed.entry);
+      });
+    });
 
   });
 </script>


### PR DESCRIPTION
- `rise-google-sheet.html`
  - using `<iron-ajax>` for making request to Sheets API
  - defined private constant `SCOPE` to define base URL for Sheets API
  - added properties `key`, `tabId`, and `cells`
  - added `prepareResponse` function to configure the response object with necessary data to return with
  - added `_onSheetError` and `_onSheetResponse` functions to handle request responses
  - `go()` function updated to configure API URL and generate request
- bower dependencies updated
- test coverage
  - data files added for mocking data returned from a Sheets API request
  - unit and integration tests added for functionality added
- demo file added to demonstrate usage so far
