### PR TITLE
Adding support for applying a range

### DIFF
--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -4,7 +4,6 @@
 <dom-module id="rise-google-sheet">
   <template>
     <iron-ajax id="sheet"
-               params='{"alt": "json"}'
                handle-as="json"
                on-response="_onSheetResponse"
                on-error="_onSheetError">
@@ -64,15 +63,51 @@
           value: function() { return []; },
           readOnly: true,
           notify: true
+        },
+
+        /**
+         * The starting column of the worksheet.
+         */
+        minColumn: {
+          type: Number,
+          value: 0
+        },
+
+        /**
+         * The last column of the worksheet to include.
+         */
+        maxColumn: {
+          type: Number,
+          value: 0
+        },
+
+        /**
+         * The starting row of the worksheet.
+         */
+        minRow: {
+          type: Number,
+          value: 0
+        },
+
+        /**
+         * The last row of the worksheet to include.
+         */
+        maxRow: {
+          type: Number,
+          value: 0
         }
       },
 
       _prepareResponse: function (resp) {
         var response = {};
 
-        response.cells = resp.feed.entry;
+        /*
+         Provide an empty array if entry property missing in feed object. This can occur if any range
+         values (minColumn, maxColumn, minRow, maxRow) are out of scope of the data entered in worksheet
+        */
+        response.cells = (resp.feed.entry) ? resp.feed.entry : [];
 
-        // TODO: provide meta data (title, authors, etc)?
+        // TODO: provide spreadsheet meta data (title, authors, etc)?
 
         return response;
       },
@@ -97,15 +132,56 @@
         }
       },
 
+      _getParams: function() {
+        var params = {};
+
+        // required in every request
+        params.alt = "json";
+
+        this.minColumn = parseInt(this.minColumn, 10);
+        this.maxColumn = parseInt(this.maxColumn, 10);
+        this.minRow = parseInt(this.minRow, 10);
+        this.maxRow = parseInt(this.maxRow, 10);
+
+        if (!isNaN(this.minColumn) && this.minColumn !== 0) {
+          params["min-col"] = this.minColumn;
+        }
+
+        if (!isNaN(this.maxColumn) && this.maxColumn !== 0) {
+          params["max-col"] = this.maxColumn;
+        }
+
+        if (!isNaN(this.minRow) && this.minRow !== 0) {
+          params["min-row"] = this.minRow;
+        }
+
+        if (!isNaN(this.maxRow) && this.maxRow !== 0) {
+          params["max-row"] = this.maxRow;
+        }
+
+        return params;
+      },
+
+      _getUrl: function() {
+        return SCOPE + "/cells/" + this.key + "/" +  this.tabId + "/public/full";
+      },
+
       /**
        * Performs a request to obtain the Google Sheet data
        *
        * @method go
        */
       go: function() {
-        var url = SCOPE + "/cells/" + this.key + "/" +  this.tabId + "/public/full";
+        // key is required, don't make request if missing
+        if (this.key === "") {
+          return;
+        }
 
-        this.$.sheet.url = url;
+        // apply url and params to the iron-ajax instance
+        this.$.sheet.url = this._getUrl();
+        this.$.sheet.params = this._getParams();
+
+        // make request
         this.$.sheet.generateRequest();
       }
 

--- a/test/data/sheet.js
+++ b/test/data/sheet.js
@@ -26,20 +26,21 @@ var sheetData = {
           }
         ],
         "content": {
-          "$t": "Description",
+          "$t": "Name",
           "type": "text"
         },
         "gs$cell": {
-          "$t": "Description",
+          "$t": "Name",
           "col": "1",
+          "inputValue": "Name",
           "row": "1"
         },
         "id": {
-          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R1C1"
+          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full/R1C1"
         },
         "link": [
           {
-            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R1C1",
+            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full/R1C1",
             "rel": "self",
             "type": "application/atom+xml"
           }
@@ -60,20 +61,21 @@ var sheetData = {
           }
         ],
         "content": {
-          "$t": "Number",
+          "$t": "Type",
           "type": "text"
         },
         "gs$cell": {
-          "$t": "Number",
+          "$t": "Type",
           "col": "2",
+          "inputValue": "Type",
           "row": "1"
         },
         "id": {
-          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R1C2"
+          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full/R1C2"
         },
         "link": [
           {
-            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R1C2",
+            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full/R1C2",
             "rel": "self",
             "type": "application/atom+xml"
           }
@@ -94,20 +96,21 @@ var sheetData = {
           }
         ],
         "content": {
-          "$t": "Type",
+          "$t": "Total",
           "type": "text"
         },
         "gs$cell": {
-          "$t": "Type",
+          "$t": "Total",
           "col": "3",
+          "inputValue": "Total",
           "row": "1"
         },
         "id": {
-          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R1C3"
+          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full/R1C3"
         },
         "link": [
           {
-            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R1C3",
+            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full/R1C3",
             "rel": "self",
             "type": "application/atom+xml"
           }
@@ -134,14 +137,15 @@ var sheetData = {
         "gs$cell": {
           "$t": "Apple",
           "col": "1",
+          "inputValue": "Apple",
           "row": "2"
         },
         "id": {
-          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R2C1"
+          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full/R2C1"
         },
         "link": [
           {
-            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R2C1",
+            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full/R2C1",
             "rel": "self",
             "type": "application/atom+xml"
           }
@@ -162,20 +166,21 @@ var sheetData = {
           }
         ],
         "content": {
-          "$t": "123",
+          "$t": "Fruit",
           "type": "text"
         },
         "gs$cell": {
-          "$t": "123",
+          "$t": "Fruit",
           "col": "2",
+          "inputValue": "Fruit",
           "row": "2"
         },
         "id": {
-          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R2C2"
+          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full/R2C2"
         },
         "link": [
           {
-            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R2C2",
+            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full/R2C2",
             "rel": "self",
             "type": "application/atom+xml"
           }
@@ -196,20 +201,22 @@ var sheetData = {
           }
         ],
         "content": {
-          "$t": "Fruit",
+          "$t": "23",
           "type": "text"
         },
         "gs$cell": {
-          "$t": "Fruit",
+          "$t": "23",
           "col": "3",
+          "inputValue": "23",
+          "numericValue": "23.0",
           "row": "2"
         },
         "id": {
-          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R2C3"
+          "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full/R2C3"
         },
         "link": [
           {
-            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/R2C3",
+            "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full/R2C3",
             "rel": "self",
             "type": "application/atom+xml"
           }
@@ -230,7 +237,7 @@ var sheetData = {
       "$t": "1000"
     },
     "id": {
-      "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values"
+      "$t": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full"
     },
     "link": [
       {
@@ -239,22 +246,22 @@ var sheetData = {
         "type": "application/atom+xml"
       },
       {
-        "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values",
+        "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full",
         "rel": "http://schemas.google.com/g/2005#feed",
         "type": "application/atom+xml"
       },
       {
-        "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values",
+        "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full",
         "rel": "http://schemas.google.com/g/2005#post",
         "type": "application/atom+xml"
       },
       {
-        "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values/batch",
+        "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full/batch",
         "rel": "http://schemas.google.com/g/2005#batch",
         "type": "application/atom+xml"
       },
       {
-        "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/values?alt=json",
+        "href": "https://spreadsheets.google.com/feeds/cells/abc123/1/public/full?alt=json",
         "rel": "self",
         "type": "application/atom+xml"
       }
@@ -266,7 +273,7 @@ var sheetData = {
       "$t": "6"
     },
     "title": {
-      "$t": "Test Sheet",
+      "$t": "Food",
       "type": "text"
     },
     "updated": {

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 
-<rise-google-sheet id="request" key="abc123"></rise-google-sheet>
+<rise-google-sheet id="request"></rise-google-sheet>
 
 <script src="data/sheet.js"></script>
 <script src="data/error.js"></script>
@@ -87,6 +87,116 @@
         assert.property(response, "cells");
         assert.isArray(response.cells);
         assert.deepEqual(response.cells, sheetData.feed.entry);
+      });
+    });
+
+    suite("_getParams", function() {
+      var params,
+        standardParams = {
+          "alt": "json"
+        };
+
+      teardown(function() {
+        sheetRequest.minColumn = 0;
+        sheetRequest.maxColumn = 0;
+        sheetRequest.minRow = 0;
+        sheetRequest.maxRow = 0;
+      });
+
+      test("should return an object with 'alt' property only, no range properties", function () {
+        params = sheetRequest._getParams();
+
+        assert.property(params, "alt");
+        assert.isString(params.alt);
+        assert.deepEqual(params, standardParams);
+      });
+
+      test("should return an object that contains 'min-col' property", function () {
+        sheetRequest.minColumn = 2;
+
+        params = sheetRequest._getParams();
+
+        assert.property(params, "min-col");
+        assert.isNumber(params["min-col"]);
+        assert.equal(params["min-col"], 2);
+      });
+
+      test("should return an object that contains 'max-col' property", function () {
+        sheetRequest.maxColumn = 2;
+
+        params = sheetRequest._getParams();
+
+        assert.property(params, "max-col");
+        assert.isNumber(params["max-col"]);
+        assert.equal(params["max-col"], 2);
+      });
+
+      test("should return an object that contains 'min-row' property", function () {
+        sheetRequest.minRow = 2;
+
+        params = sheetRequest._getParams();
+
+        assert.property(params, "min-row");
+        assert.isNumber(params["min-row"]);
+        assert.equal(params["min-row"], 2);
+      });
+
+      test("should return an object that contains 'max-row' property", function () {
+        sheetRequest.maxRow = 2;
+
+        params = sheetRequest._getParams();
+
+        assert.property(params, "max-row");
+        assert.isNumber(params["max-row"]);
+        assert.equal(params["max-row"], 2);
+      });
+    });
+
+    suite("_getUrl", function () {
+      var url;
+
+      teardown(function() {
+        sheetRequest.key = "";
+        sheetRequest.tabId = 1;
+      });
+
+      test("should return correct URL to use for generating a request to Sheets API", function () {
+        sheetRequest.key = "abc123";
+        sheetRequest.tabId = 2;
+
+        url = sheetRequest._getUrl();
+
+        assert.isString(url);
+        assert.equal(url, "https://spreadsheets.google.com/feeds/cells/abc123/2/public/full");
+      });
+    });
+
+    suite("go", function () {
+      var requestSpy;
+
+      teardown(function() {
+        sheetRequest.key = "";
+      });
+
+      test("should not make call to generate request without a value for 'key'", function () {
+        requestSpy = sinon.spy(sheetRequest.$.sheet, "generateRequest");
+
+        sheetRequest.go();
+
+        assert.equal(requestSpy.callCount, 0);
+
+        sheetRequest.$.sheet.generateRequest.restore();
+      });
+
+      test("should generate request to Sheets API", function () {
+        requestSpy = sinon.spy(sheetRequest.$.sheet, "generateRequest");
+
+        sheetRequest.key = "abc123";
+        sheetRequest.go();
+
+        assert(requestSpy.calledOnce);
+
+        sheetRequest.$.sheet.generateRequest.restore();
       });
     });
 


### PR DESCRIPTION
- `rise-google-sheet.html`
  - removing `params` from `<iron-ajax>` instance so they can be applied dynamically
  - added `_getUrl` function to allow for unit testing value
  - added `_getParams` function for configuring necessary request params based on range values
  - `prepareResponse` updated to provide an empty array as `cells` value if `entry` property missing from response
  - `go()` updated to return if missing `key` value and obtaining params and url values from new functions
- unit tests added for new functionality
- corrected mock data to use full projection values
