### PR TITLE
Adding support for a refresh

### DIFF
--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -56,6 +56,14 @@
         },
 
         /**
+         * The number of seconds before another request will be made.
+         */
+        refresh: {
+          type: Number,
+          value: 0
+        },
+
+        /**
          * Returns a list of cell data.
          */
         cells: {
@@ -98,6 +106,23 @@
         }
       },
 
+      _requestPending: false,
+
+      _startTimer: function() {
+        var refreshFn = this.go,
+          self = this;
+
+        this.refresh = parseInt(this.refresh, 10);
+
+        if (!isNaN(this.refresh) && this.refresh !== 0) {
+          this.refresh = (this.refresh < 10) ? 10 : this.refresh;
+
+          this.debounce("refresh", function () {
+            refreshFn.call(self);
+          }, this.refresh * 1000);
+        }
+      },
+
       _prepareResponse: function (resp) {
         var response = {};
 
@@ -113,7 +138,13 @@
       },
 
       _onSheetError: function(e, err) {
+        // reset the value of cells
+        this._setCells([]);
+
         this.fire("rise-google-sheet-error", err.error.message);
+
+        this._requestPending = false;
+        // not calling _startTimer(), can't distinguish between error to determine if refresh is appropriate
       },
 
       _onSheetResponse: function(e, resp) {
@@ -129,6 +160,13 @@
           this._setCells(responseData.cells);
 
           this.fire("rise-google-sheet-response", responseData);
+
+          this._requestPending = false;
+          this._startTimer();
+        }
+        else {
+          this._requestPending = false;
+          this._startTimer();
         }
       },
 
@@ -172,10 +210,13 @@
        * @method go
        */
       go: function() {
-        // key is required, don't make request if missing
-        if (this.key === "") {
+        // key is required, don't make request if missing 'key' or if a previous request is pending
+        if (this.key === "" || this._requestPending) {
           return;
         }
+
+        // set flag to prevent further requests in case go() function is called before prior request responds
+        this._requestPending = true;
 
         // apply url and params to the iron-ajax instance
         this.$.sheet.url = this._getUrl();

--- a/test/rise-google-sheet-integration.html
+++ b/test/rise-google-sheet-integration.html
@@ -38,6 +38,8 @@
       test("should return an Array of cell objects", function(done) {
         responseHandler = function(response) {
           assert.deepEqual(response.detail.cells, sheetData.feed.entry);
+
+          sheetRequest.removeEventListener("rise-google-sheet-response", responseHandler);
           done();
         };
 

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -176,6 +176,7 @@
 
       teardown(function() {
         sheetRequest.key = "";
+        sheetRequest._requestPending = false;
       });
 
       test("should not make call to generate request without a value for 'key'", function () {
@@ -198,6 +199,46 @@
 
         sheetRequest.$.sheet.generateRequest.restore();
       });
+
+      test("should not execute further request when there is one pending a response", function() {
+        requestSpy = sinon.spy(sheetRequest.$.sheet, "generateRequest");
+
+        sheetRequest.key = "abc123";
+        sheetRequest.go();
+        sheetRequest.go();
+        sheetRequest.go();
+
+        assert(requestSpy.calledOnce);
+
+        sheetRequest.$.sheet.generateRequest.restore();
+      });
+    });
+
+    suite("_startTimer", function() {
+      var timerSpy;
+
+      teardown(function() {
+        sheetRequest.refresh = 0;
+      });
+
+      test("should enforce a minimum refresh interval of 10 (seconds)", function() {
+        sheetRequest.refresh = 5;
+        sheetRequest._startTimer();
+        assert.equal(sheetRequest.refresh, 10);
+      });
+
+      test("should make a new request for data", function() {
+        timerSpy = sinon.spy(sheetRequest, "go");
+
+        sheetRequest.refresh = 30;
+        sheetRequest._startTimer();
+
+        clock.tick(30000);
+        assert(timerSpy.calledOnce);
+
+        sheetRequest.go.restore();
+      });
+
     });
 
   });


### PR DESCRIPTION
- `rise-google-sheet.html`
  - added `refresh` property
  - added `_startTimer` function, `go()` will be called periodically based on refresh value in seconds
  - added `_pendingRequest` flag to prevent multiple requests happening when the initial one hasn't responded yet
  - `_onSheetResponse()` and `_onSheetError()` updated to set `_pendingRequest` flag and start the refresh timer
- unit tests added for new functionality
