### PR TITLE
Adding support for offline caching

### DIFF
--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -20,6 +20,16 @@
 
     var SCOPE = "https://spreadsheets.google.com/feeds";
 
+    var LOCAL_STORAGE_NAME = "risesheet";
+
+    function supportsLocalStorage() {
+      try {
+        return "localStorage" in window && window.localStorage !== null;
+      } catch (e) {
+        return false;
+      }
+    }
+
     Polymer({
       is: "rise-google-sheet",
 
@@ -108,6 +118,21 @@
 
       _requestPending: false,
 
+      _getCachedData: function () {
+        if (supportsLocalStorage()) {
+          // retrieve cached data and parse back
+          return JSON.parse(localStorage.getItem(LOCAL_STORAGE_NAME));
+        }
+
+        return null;
+      },
+
+      _setCachedData: function (data) {
+        if (supportsLocalStorage()) {
+          localStorage.setItem(LOCAL_STORAGE_NAME, JSON.stringify(data));
+        }
+      },
+
       _startTimer: function() {
         var refreshFn = this.go,
           self = this;
@@ -138,13 +163,54 @@
       },
 
       _onSheetError: function(e, err) {
+        // in case there are other instances of rise-google-sheet
+        e.stopPropagation();
+
         // reset the value of cells
         this._setCells([]);
+
+        // if cached data exists, remove it
+        if (this._getCachedData()) {
+          localStorage.removeItem(LOCAL_STORAGE_NAME);
+        }
 
         this.fire("rise-google-sheet-error", err.error.message);
 
         this._requestPending = false;
-        // not calling _startTimer(), can't distinguish between error to determine if refresh is appropriate
+        // not calling _startTimer(), can't distinguish between errors to determine if refresh is appropriate
+      },
+
+      _handleEmptyResponse: function (e) {
+        var cachedData;
+
+        // check xhr.status to be 0, <iron-ajax> treats no status (no internet connection) as successful
+        if (e.target.lastRequest && e.target.lastRequest.xhr.status === 0) {
+          cachedData = this._getCachedData();
+
+          /*
+           * NOTE:
+           * Unfortunately xhr.status is also 0 when incorrect tab id is used. If cached data exists,
+           * it will be provided even though tab id is incorrect.
+           */
+
+          if (cachedData) {
+            this._setCells(cachedData.cells);
+
+            this.fire("rise-google-sheet-response", cachedData);
+
+            this._requestPending = false;
+            this._startTimer();
+
+            return;
+          }
+        }
+
+        // no response and no cached data available, process this as an error
+        this._onSheetError(e, {
+          error: {
+            message: "Empty response and no cached data available."
+          }
+        });
       },
 
       _onSheetResponse: function(e, resp) {
@@ -156,6 +222,9 @@
         if (resp && resp.response) {
           responseData = this._prepareResponse(resp.response);
 
+          // cache the data if possible
+          this._setCachedData(responseData);
+
           // use setter method to apply cells value because this property is read only
           this._setCells(responseData.cells);
 
@@ -163,10 +232,17 @@
 
           this._requestPending = false;
           this._startTimer();
+
         }
         else {
-          this._requestPending = false;
-          this._startTimer();
+          /*
+           * This can happen here because <iron-ajax> sets xhr.status to 0 in certain circumstances.
+           * There is an open issue regarding the behaviour:
+           *
+           * https://github.com/PolymerElements/iron-ajax/issues/45
+           *
+           */
+          this._handleEmptyResponse(e);
         }
       },
 
@@ -222,7 +298,6 @@
         this.$.sheet.url = this._getUrl();
         this.$.sheet.params = this._getParams();
 
-        // make request
         this.$.sheet.generateRequest();
       }
 

--- a/test/rise-google-sheet-integration.html
+++ b/test/rise-google-sheet-integration.html
@@ -15,6 +15,7 @@
 <rise-google-sheet id="request" key="abc123"></rise-google-sheet>
 
 <script src="data/sheet.js"></script>
+<script src="data/error.js"></script>
 
 <script>
   suite("rise-google-sheet", function() {
@@ -24,7 +25,6 @@
     // Runs for every suite.
     suiteSetup(function() {
       server = sinon.fakeServer.create();
-      server.respondImmediately = true;
 
       clock = sinon.useFakeTimers();
     });
@@ -34,9 +34,16 @@
       clock.restore();
     });
 
+    setup(function() {
+      localStorage.removeItem("risesheet"); // clear localStorage
+    });
+
     suite("request data", function() {
-      test("should return an Array of cell objects", function(done) {
+      test("should return an Array of cell objects when server/API request responds successfully", function(done) {
         responseHandler = function(response) {
+
+          assert.property(response.detail, "cells", "detail.cells property exists");
+          assert.isArray(response.detail.cells, "detail.cells is an Array");
           assert.deepEqual(response.detail.cells, sheetData.feed.entry);
 
           sheetRequest.removeEventListener("rise-google-sheet-response", responseHandler);
@@ -46,6 +53,46 @@
         sheetRequest.addEventListener("rise-google-sheet-response", responseHandler);
         server.respondWith([200, {}, JSON.stringify(sheetData)]);
         sheetRequest.go();
+        server.respond();
+      });
+
+      test("should return error when server/API request responds unsuccessful", function (done) {
+        responseHandler = function(response) {
+
+          assert.isString(response.detail, "detail is a String");
+          assert.equal(response.detail, errorData.error.message);
+
+          sheetRequest.removeEventListener("rise-google-sheet-error", responseHandler);
+          done();
+        };
+
+        sheetRequest.addEventListener("rise-google-sheet-error", responseHandler);
+        server.respondWith([400, {}, JSON.stringify(errorData)]);
+        sheetRequest.go();
+        server.respond();
+      });
+
+    });
+
+    suite("offline cached data", function() {
+      test("should return cached Array of cell objects when <iron-ajax> sets lastRequest.xhr.status to 0", function () {
+        responseHandler = function(response) {
+
+          assert.deepEqual(response.detail.cells, sheetData.feed.entry);
+
+          sheetRequest.removeEventListener("rise-google-sheet-response", responseHandler);
+          done();
+        };
+
+        // data will get cached
+        server.respondWith([200, {}, JSON.stringify(sheetData)]);
+        sheetRequest.go();
+        server.respond();
+
+        server.respondWith([400, {}, ""]);
+        sheetRequest.addEventListener("rise-google-sheet-response", responseHandler);
+        sheetRequest.go();
+        server.respond();
       });
     });
 

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -32,41 +32,47 @@
 
     setup(function() {
       responded = false;
+      localStorage.removeItem("risesheet"); // clear localStorage
     });
 
     suite("_onSheetError", function () {
-      test("should fire rise-google-sheet-error if there is a problem with the Sheets request", function(done) {
+      var e = {
+        "stopPropagation": function () {}
+      };
+
+      test("should fire rise-google-sheet-error when handling <iron-ajax> request error ", function(done) {
         listener = function(response) {
           responded = true;
-
-          assert.isString(response.detail, "detail is a String");
-          assert.equal(response.detail, errorData.error.message, "detail value is the error message");
 
           sheetRequest.removeEventListener("rise-google-sheet-error", listener);
         };
 
         sheetRequest.addEventListener("rise-google-sheet-error", listener);
-        sheetRequest._onSheetError({}, errorData);
+        sheetRequest._onSheetError(e, errorData);
         assert.isTrue(responded);
         done();
       });
     });
 
     suite("_onSheetResponse", function () {
-      test("should fire rise-google-sheet-response and provide an Array of cell objects", function(done) {
-        var resp = {
-            "response": _.clone(sheetData)
-          },
-          e = {
-            "stopPropagation": function () {}
-          };
+      var resp = {
+          "response": _.clone(sheetData)
+        },
+        e = {
+          "stopPropagation": function () {}
+        };
+
+      teardown(function() {
+        sheetRequest._setCells([]);
+      });
+
+      test("should fire rise-google-sheet-response, set cells property, and call _setCachedData()", function(done) {
+        var setCachedDataStub = sinon.stub(sheetRequest, "_setCachedData", function () {});
 
         listener = function(response) {
           responded = true;
 
           assert.property(response.detail, "cells", "detail.cells property exists");
-          assert.isArray(response.detail.cells, "detail.cells is an Array");
-          assert.deepEqual(response.detail.cells, resp.response.feed.entry, "detail.cells value is correct");
 
           sheetRequest.removeEventListener("rise-google-sheet-response", listener);
         };
@@ -74,10 +80,36 @@
         sheetRequest.addEventListener("rise-google-sheet-response", listener);
         sheetRequest._onSheetResponse(e, resp);
 
-        assert.deepEqual(sheetRequest.cells, resp.response.feed.entry);
+        assert(setCachedDataStub.calledOnce, "call to _setCachedData is made");
+        assert.deepEqual(sheetRequest.cells, resp.response.feed.entry, "cells property is set correctly");
         assert.isTrue(responded);
+
+        sheetRequest._setCachedData.restore();
+
         done();
       });
+
+      test("should not fire rise-google-sheet-response and make a call to _handleEmptyResponse()", function(done) {
+        var emptyResponseStub = sinon.stub(sheetRequest, "_handleEmptyResponse", function (){});
+
+        listener = function(response) {
+          responded = true;
+
+          sheetRequest.removeEventListener("rise-google-sheet-response", listener);
+        };
+
+        sheetRequest.addEventListener("rise-google-sheet-response", listener);
+        sheetRequest._onSheetResponse(e);
+
+        assert(emptyResponseStub.calledOnce);
+        assert(emptyResponseStub.calledWith(e));
+        assert.isFalse(responded);
+
+        sheetRequest._handleEmptyResponse.restore();
+
+        done();
+      });
+
     });
 
     suite("_prepareResponse", function() {
@@ -172,51 +204,42 @@
     });
 
     suite("go", function () {
-      var requestSpy;
+      var requestStub;
+
+      setup(function() {
+        requestStub = sinon.stub(sheetRequest.$.sheet, "generateRequest", function (){});
+      });
 
       teardown(function() {
         sheetRequest.key = "";
         sheetRequest._requestPending = false;
+        sheetRequest.$.sheet.generateRequest.restore();
       });
 
       test("should not make call to generate request without a value for 'key'", function () {
-        requestSpy = sinon.spy(sheetRequest.$.sheet, "generateRequest");
-
         sheetRequest.go();
 
-        assert.equal(requestSpy.callCount, 0);
-
-        sheetRequest.$.sheet.generateRequest.restore();
+        assert.equal(requestStub.callCount, 0);
       });
 
       test("should generate request to Sheets API", function () {
-        requestSpy = sinon.spy(sheetRequest.$.sheet, "generateRequest");
-
         sheetRequest.key = "abc123";
         sheetRequest.go();
 
-        assert(requestSpy.calledOnce);
-
-        sheetRequest.$.sheet.generateRequest.restore();
+        assert(requestStub.calledOnce);
       });
 
       test("should not execute further request when there is one pending a response", function() {
-        requestSpy = sinon.spy(sheetRequest.$.sheet, "generateRequest");
-
         sheetRequest.key = "abc123";
         sheetRequest.go();
         sheetRequest.go();
         sheetRequest.go();
 
-        assert(requestSpy.calledOnce);
-
-        sheetRequest.$.sheet.generateRequest.restore();
+        assert(requestStub.calledOnce);
       });
     });
 
     suite("_startTimer", function() {
-      var timerSpy;
-
       teardown(function() {
         sheetRequest.refresh = 0;
       });
@@ -228,15 +251,70 @@
       });
 
       test("should make a new request for data", function() {
-        timerSpy = sinon.spy(sheetRequest, "go");
+        var timerStub = sinon.stub(sheetRequest, "go", function () {});
 
         sheetRequest.refresh = 30;
         sheetRequest._startTimer();
 
         clock.tick(30000);
-        assert(timerSpy.calledOnce);
+        assert(timerStub.calledOnce);
 
         sheetRequest.go.restore();
+      });
+
+    });
+
+    suite("_handleEmptyResponse", function () {
+      teardown(function() {
+        sheetRequest._setCells([]);
+      });
+
+      test("should fire rise-google-sheet-response when <iron-ajax> lastRequest.xhr.status is 0", function (done) {
+        var e = {
+            "stopPropagation": function () {},
+            "target": { "lastRequest": { "xhr": { "status": 0 } }
+            }
+          };
+
+        listener = function(response) {
+          responded = true;
+
+          sheetRequest.removeEventListener("rise-google-sheet-response", listener);
+        };
+
+        sinon.stub(sheetRequest, "_getCachedData", function () {
+          return sheetData;
+        });
+
+        sheetRequest.addEventListener("rise-google-sheet-response", listener);
+        sheetRequest._handleEmptyResponse(e);
+
+        assert.isTrue(responded);
+
+        sheetRequest._getCachedData.restore();
+
+        done();
+      });
+
+      test("should fire rise-google-sheet-error when '<iron-ajax>' lastRequest.xhr.status is not 0", function (done) {
+        var e = {
+          "stopPropagation": function () {},
+          "target": { "lastRequest": { "xhr": { "status": 400 } }
+          }
+        };
+
+        listener = function(response) {
+          responded = true;
+
+          sheetRequest.removeEventListener("rise-google-sheet-error", listener);
+        };
+
+        sheetRequest.addEventListener("rise-google-sheet-error", listener);
+        sheetRequest._handleEmptyResponse(e);
+
+        assert.isTrue(responded);
+
+        done();
       });
 
     });


### PR DESCRIPTION
- When a successful response is provided from API request, data is cached using `localStorage`
- When `<iron-ajax>` error occurs, any cached data is removed
- `<iron-ajax>` sets `lastRequest.xhr.status` to 0 when no status is provided from request which calls response handler instead of error. Component handles this by checking for value of 0 and considers this an offline scenario and checks for cached data, if exists sends a "rise-google-sheet-response" with the cached data. If no cached data available, it processes as an error ("rise-google-sheer-error").
- test coverage added
