### PR TITLE
Adding <content> element to local DOM

### DIFF
--- a/demo-playlist.html
+++ b/demo-playlist.html
@@ -19,23 +19,25 @@
 
 <rise-page display-id="VGZUDDWYAZHY">
 
-  <rise-playlist>
+  <rise-playlist id="playlist">
+
     <rise-playlist-item>
       <rise-google-sheet id="googleSheet"
                          key="1P5kJXEszMm-vNpaPeQ6I-rD9SGM_gqacIrHMOUrQx_I">
+        <!-- Example HTML structure -->
+        <table id="sheetTable" class="pure-table pure-table-bordered">
+          <thead>
+          <tr>
+            <!-- dynamically add column header titles -->
+          </tr>
+          </thead>
+          <tbody>
+          <!-- dynamically populate table cells -->
+          </tbody>
+        </table>
       </rise-google-sheet>
-      <!-- Example HTML structure -->
-      <table id="sheetTable" class="pure-table pure-table-bordered">
-        <thead>
-        <tr>
-          <!-- dynamically add column header titles -->
-        </tr>
-        </thead>
-        <tbody>
-        <!-- dynamically populate table cells -->
-        </tbody>
-      </table>
     </rise-playlist-item>
+
   </rise-playlist>
 
 </rise-page>

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -8,6 +8,7 @@
                on-response="_onSheetResponse"
                on-error="_onSheetError">
     </iron-ajax>
+    <content></content>
   </template>
 </dom-module>
 


### PR DESCRIPTION
- Allowing for nested content within `<rise-google-sheet>` instance to be injected by adding `<content>` element in the local DOM
- Updated `demo-playlist.html` to nest the `<table>` structure within the `<rise-google-sheet>` instance. If there were more than one playlist item, the hiding and showing of the table content would work properly now.
