### PR TITLE
Adding return-empty attribute to provide empty cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 The `key` attribute is required which is to identify the Google Sheet you want to target. A spreadsheet's key can be found in the URL when viewing it in Google Docs (e.g. docs.google.com/spreadsheets/d/< KEY >/edit#gid=0).
 
+Optionally, the `tab-id` attribute allows for specifying a particular worksheet tab in the spreadsheet. For example, the first tab would be `tab-id="1"`.
+
 The specified feed is periodically retrieved if the `refresh` attribute is set, although a minimum refresh time of 10 seconds is enforced.
 
 ### Range
@@ -15,6 +17,17 @@ For example, to retrieve cells for every row after the first row, and only in th
 
 ```
 <rise-google-sheet key="abc123" min-row="2" min-column="4" max-column="4"></rise-google-sheet>
+```
+
+### Empty cells
+Optionally, the `return-empty` attribute allows for retrieving all cell data in a worksheet including empty cells. This is helpful if perhaps you want to visualize a table with the data and it's important that empty cells are included in the response to accurately populate the table with the data. 
+
+Please note that using `return-empty` will return all empty cells, including the excess columns and rows in your worksheet. If this is not desired then you can workaround this by deleting the excess columns and rows from your worksheet. Alternatively, use the range attributes to specify exactly which cells are required.
+
+For example, to retrieve cells for columns 1-5 and rows 2-10 **and** include empty cells:
+
+```
+<rise-google-sheet key="abc123" max-column="5" min-row="2" max-row="10" return-empty="true"></rise-google-sheet>
 ```
 
 ## Usage

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],

--- a/demo/index.html
+++ b/demo/index.html
@@ -25,7 +25,8 @@
 
     <rise-playlist-item>
       <rise-google-sheet id="googleSheet"
-                         key="1P5kJXEszMm-vNpaPeQ6I-rD9SGM_gqacIrHMOUrQx_I">
+                         key="1P5kJXEszMm-vNpaPeQ6I-rD9SGM_gqacIrHMOUrQx_I"
+                         max-column="4" max-row="6" return-empty="true">
         <!-- Example HTML structure -->
         <table id="sheetTable" class="pure-table pure-table-bordered">
           <thead>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Rise Vision web component for retrieving Google Sheet data",
   "scripts": {
     "test": "gulp test",

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -42,6 +42,20 @@ For example, to retrieve cells for every row after the first row, and only in th
 
     <rise-google-sheet key="abc123" min-row="2" min-column="4" max-column="4"></rise-google-sheet>
 
+#### Empty cells
+
+Optionally, the `return-empty` attribute allows for retrieving all cell data in a worksheet including empty cells.
+This is helpful if perhaps you want to visualize a table with the data and it's important that empty cells are
+included in the response to accurately populate the table with the data.
+
+Please note that using `return-empty` will return all empty cells, including the excess columns and rows
+in your worksheet. If this is not desired then you can workaround this by deleting the excess columns and rows
+from your worksheet. Alternatively, use the range attributes to specify exactly which cells are required.
+
+For example, to retrieve cells for columns 1-5 and rows 1-10 **and** include empty cells:
+
+    <rise-google-sheet key="abc123" max-column="5" max-row="10" return-empty="true"></rise-google-sheet>
+
 @demo
 -->
 <dom-module id="rise-google-sheet">
@@ -144,6 +158,14 @@ For example, to retrieve cells for every row after the first row, and only in th
         maxRow: {
           type: Number,
           value: 0
+        },
+
+        /**
+         * Include empty cells of the worksheet.
+         */
+        returnEmpty: {
+          type: Boolean,
+          value: false
         }
       },
 
@@ -306,6 +328,11 @@ For example, to retrieve cells for every row after the first row, and only in th
 
         // required in every request
         params.alt = "json";
+
+        // return empty cells
+        if (this.returnEmpty) {
+          params["return-empty"] = true;
+        }
 
         this.minColumn = parseInt(this.minColumn, 10);
         this.maxColumn = parseInt(this.maxColumn, 10);

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -155,18 +155,29 @@
         };
 
       teardown(function() {
+        sheetRequest.returnEmpty = false;
         sheetRequest.minColumn = 0;
         sheetRequest.maxColumn = 0;
         sheetRequest.minRow = 0;
         sheetRequest.maxRow = 0;
       });
 
-      test("should return an object with 'alt' property only, no range properties", function () {
+      test("should return an object with 'alt' property only", function () {
         params = sheetRequest._getParams();
 
         assert.property(params, "alt");
         assert.isString(params.alt);
         assert.deepEqual(params, standardParams);
+      });
+
+      test("should return an object that contains 'return-empty` property", function () {
+        sheetRequest.returnEmpty = true;
+
+        params = sheetRequest._getParams();
+
+        assert.property(params, "return-empty");
+        assert.isBoolean(params["return-empty"]);
+        assert.isTrue(params["return-empty"]);
       });
 
       test("should return an object that contains 'min-col' property", function () {
@@ -239,6 +250,11 @@
       teardown(function() {
         sheetRequest.key = "";
         sheetRequest._requestPending = false;
+        sheetRequest.minRow = 0;
+        sheetRequest.maxRow = 0;
+        sheetRequest.minColumn = 0;
+        sheetRequest.maxColumn = 0;
+        sheetRequest.returnEmpty = false;
         sheetRequest.$.sheet.generateRequest.restore();
       });
 
@@ -246,6 +262,34 @@
         sheetRequest.go();
 
         assert.equal(requestStub.callCount, 0);
+      });
+
+      test("should ensure the correct url is provided in request to Sheets API", function () {
+        sheetRequest.key = "abc123";
+        sheetRequest.tabId = 2;
+        sheetRequest.go();
+
+        assert.equal(sheetRequest.$.sheet.url, "https://spreadsheets.google.com/feeds/cells/abc123/2/public/full");
+      });
+
+      test("should ensure all required and optional params are included in request to Sheets API", function () {
+        sheetRequest.key = "abc123";
+        sheetRequest.minRow = 2;
+        sheetRequest.maxRow = 2;
+        sheetRequest.minColumn = 2;
+        sheetRequest.maxColumn = 2;
+        sheetRequest.returnEmpty = true;
+
+        sheetRequest.go();
+
+        assert.deepEqual(sheetRequest.$.sheet.params, {
+          "alt": "json",
+          "return-empty": true,
+          "min-col": 2,
+          "max-col": 2,
+          "min-row": 2,
+          "max-row": 2
+        });
       });
 
       test("should generate request to Sheets API", function () {


### PR DESCRIPTION
- Leveraging the Sheets API param `return-empty` to have the API return all cell values, empty or not
- Providing a new boolean attribute `return-empty` to specify if empty values is desired (default is false)
- Adding unit test coverage
- Adding README and documentation regarding empty cells
- Version bump (minor version) `1.1.0`
