### PR TITLE
Append sheet key to local storage key value

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,5 @@
 dependencies:
   pre:
-    # latest stable chrome
-    - curl -L -o google-chrome-stable.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-    - sudo dpkg -i google-chrome-stable.deb
-    # make chrome lxc-friendly
-    - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
-    - rm google-chrome-stable.deb
     - npm install -g gulp
     - npm install -g web-component-tester
   post:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,6 @@
   var gulp = require("gulp");
   var bump = require("gulp-bump");
   var jshint = require("gulp-jshint");
-  var rename = require("gulp-rename");
   var uglify = require('gulp-uglify');
   var colors = require("colors");
   var runSequence = require("run-sequence");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Rise Vision web component for retrieving Google Sheet data",
   "scripts": {
     "test": "gulp test",
@@ -32,7 +32,6 @@
     "gulp": "~3.8.10",
     "gulp-bower": "~0.0.10",
     "gulp-bump": "~0.2.0",
-    "gulp-rename": "~1.2.0",
     "gulp-uglify": "~1.2.0",
     "gulp-jshint": "~1.10.0",
     "jshint-stylish": "~1.0.2",

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -78,7 +78,7 @@ For example, to retrieve cells for columns 1-5 and rows 1-10 **and** include emp
 
     var SCOPE = "https://spreadsheets.google.com/feeds";
 
-    var LOCAL_STORAGE_NAME = "risesheet";
+    var LOCAL_STORAGE_BASE_NAME = "risesheet";
 
     function supportsLocalStorage() {
       try {
@@ -187,10 +187,14 @@ For example, to retrieve cells for columns 1-5 and rows 1-10 **and** include emp
        * @event rise-google-sheet-error
        */
 
+      _getLocalStorageKey: function () {
+        return LOCAL_STORAGE_BASE_NAME + "_" + this.key;
+      },
+
       _getCachedData: function () {
         if (supportsLocalStorage()) {
           // retrieve cached data and parse back
-          return JSON.parse(localStorage.getItem(LOCAL_STORAGE_NAME));
+          return JSON.parse(localStorage.getItem(this._getLocalStorageKey()));
         }
 
         return null;
@@ -199,7 +203,7 @@ For example, to retrieve cells for columns 1-5 and rows 1-10 **and** include emp
       _setCachedData: function (data) {
         if (supportsLocalStorage()) {
           try {
-            localStorage.setItem(LOCAL_STORAGE_NAME, JSON.stringify(data));
+            localStorage.setItem(this._getLocalStorageKey(), JSON.stringify(data));
           } catch(e) {
             console.warn(e.message);
           }
@@ -245,7 +249,7 @@ For example, to retrieve cells for columns 1-5 and rows 1-10 **and** include emp
         // if cached data exists, remove it
         if (this._getCachedData()) {
           try {
-            localStorage.removeItem(LOCAL_STORAGE_NAME);
+            localStorage.removeItem(this._getLocalStorageKey());
           } catch (ex) {
             console.warn(ex.message);
           }

--- a/test/rise-google-sheet-integration.html
+++ b/test/rise-google-sheet-integration.html
@@ -75,7 +75,7 @@
     });
 
     suite("offline cached data", function() {
-      test("should return cached Array of cell objects when <iron-ajax> sets lastRequest.xhr.status to 0", function () {
+      test("should return cached Array of cell objects when <iron-ajax> sets lastRequest.xhr.status to 0", function (done) {
         responseHandler = function(response) {
 
           assert.deepEqual(response.detail.cells, sheetData.feed.entry);

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -12,11 +12,11 @@
 </head>
 <body>
 
-<rise-google-sheet id="request"></rise-google-sheet>
+<rise-google-sheet id="request" key="abc123"></rise-google-sheet>
 
 <script src="data/sheet.js"></script>
 <script src="data/error.js"></script>
-<script src="/node_modules/widget-tester/mocks/localStorage-mock.js"></script>
+<script src="../node_modules/widget-tester/mocks/localStorage-mock.js"></script>
 
 <script>
   suite("rise-google-sheet", function () {
@@ -33,7 +33,15 @@
 
     setup(function() {
       responded = false;
-      localStorage.removeItem("risesheet"); // clear localStorage
+      localStorage.removeItem("risesheet_" + sheetRequest.key); // clear localStorage
+    });
+
+    suite("_getLocalStorageKey", function () {
+
+      test("should return correct local storage key using unique sheet key", function () {
+        assert.equal(sheetRequest._getLocalStorageKey(), "risesheet_abc123");
+      });
+
     });
 
     suite("_onSheetError", function () {
@@ -43,7 +51,7 @@
 
       teardown(function () {
         window.localStorageError = false;
-        localStorage.removeItem("risesheet");
+        localStorage.removeItem(sheetRequest._getLocalStorageKey());
       });
 
       test("should fire rise-google-sheet-error when handling <iron-ajax> request error ", function(done) {
@@ -60,17 +68,17 @@
       });
 
       test("should remove item from localStorage if it exists", function () {
-        localStorage.setItem("risesheet", JSON.stringify({cells: sheetData.feed.entry}));
+        localStorage.setItem(sheetRequest._getLocalStorageKey(), JSON.stringify({cells: sheetData.feed.entry}));
 
         sheetRequest._onSheetError(e, errorData);
 
-        assert.isNull(localStorage.getItem("risesheet"));
+        assert.isNull(localStorage.getItem(sheetRequest._getLocalStorageKey()));
       });
 
       test("should catch error thrown by localStorage.removeItem and log a warning in console", function () {
         var consoleSpy = sinon.spy(console, "warn");
 
-        localStorage.setItem("risesheet", JSON.stringify({cells: sheetData.feed.entry}));
+        localStorage.setItem(sheetRequest._getLocalStorageKey(), JSON.stringify({cells: sheetData.feed.entry}));
 
         // force an error from localStorage.removeItem()
         window.localStorageError = true;
@@ -92,7 +100,7 @@
 
       teardown(function() {
         sheetRequest._setCells([]);
-        localStorage.removeItem("risesheet");
+        localStorage.removeItem(sheetRequest._getLocalStorageKey());
       });
 
       test("should fire rise-google-sheet-response, set cells property, and save to localStorage", function(done) {
@@ -108,7 +116,7 @@
         sheetRequest._onSheetResponse(e, resp);
 
         assert.deepEqual(sheetRequest.cells, resp.response.feed.entry, "cells property is set correctly");
-        assert.deepEqual(JSON.parse(localStorage.getItem("risesheet")), {cells: sheetData.feed.entry},
+        assert.deepEqual(JSON.parse(localStorage.getItem(sheetRequest._getLocalStorageKey())), {cells: sheetData.feed.entry},
           "localStorage saved data correctly");
         assert.isTrue(responded);
 
@@ -338,7 +346,7 @@
 
       teardown(function () {
         window.localStorageError = false;
-        localStorage.removeItem("risesheet");
+        localStorage.removeItem(sheetRequest._getLocalStorageKey());
       });
 
       test("should catch error thrown by localStorage.setItem and log a warning in console", function () {
@@ -356,7 +364,7 @@
       test("should ensure data passed in localStorage.setItem() is stringified", function () {
         sheetRequest._setCachedData({cells: sheetData.feed.entry});
 
-        var value = localStorage.getItem("risesheet");
+        var value = localStorage.getItem(sheetRequest._getLocalStorageKey());
 
         assert.isString(value);
       });
@@ -367,7 +375,7 @@
       var value;
 
       teardown(function () {
-        localStorage.removeItem("risesheet");
+        localStorage.removeItem(sheetRequest._getLocalStorageKey());
       });
 
       test("Should return null when no cached data exists", function () {
@@ -377,7 +385,7 @@
       });
 
       test("Should ensure value returned has been parsed as JSON", function () {
-        localStorage.setItem("risesheet", JSON.stringify({cells: sheetData.feed.entry}));
+        localStorage.setItem(sheetRequest._getLocalStorageKey(), JSON.stringify({cells: sheetData.feed.entry}));
 
         value = sheetRequest._getCachedData();
 
@@ -388,7 +396,7 @@
     suite("_handleEmptyResponse", function () {
       teardown(function() {
         sheetRequest._setCells([]);
-        localStorage.removeItem("risesheet");
+        localStorage.removeItem(sheetRequest._getLocalStorageKey());
       });
 
       test("should fire rise-google-sheet-response when <iron-ajax> lastRequest.xhr.status is 0", function (done) {
@@ -405,7 +413,7 @@
         };
 
         // ensure cached data exists
-        localStorage.setItem("risesheet", JSON.stringify({cells:sheetData.feed.entry}));
+        localStorage.setItem(sheetRequest._getLocalStorageKey(), JSON.stringify({cells:sheetData.feed.entry}));
 
         sheetRequest.addEventListener("rise-google-sheet-response", listener);
         sheetRequest._handleEmptyResponse(e);


### PR DESCRIPTION
- Local storage key now appends the key of the spreadsheet being used to allow for targeting local storage to specific spreadsheet
- CCI fix
- test coverage added
- version bump
