### PR TITLE
Ensuring to start refresh timer after firing rise-google-sheet-error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Rise Vision web component for retrieving Google Sheet data",
   "scripts": {
     "test": "gulp test",

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -258,7 +258,7 @@ For example, to retrieve cells for columns 1-5 and rows 1-10 **and** include emp
         this.fire("rise-google-sheet-error", err.error.message);
 
         this._requestPending = false;
-        // not calling _startTimer(), can't distinguish between errors to determine if refresh is appropriate
+        this._startTimer();
       },
 
       _handleEmptyResponse: function (e) {

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -88,6 +88,16 @@
         assert(consoleSpy.calledOnce);
         console.warn.restore();
       });
+
+      test("should start a refresh timer after firing rise-google-sheet-error", function () {
+        var timerStub = sinon.stub(sheetRequest, "_startTimer");
+
+        sheetRequest._onSheetError(e, errorData);
+        assert(timerStub.calledOnce);
+
+        sheetRequest._startTimer.restore();
+      });
+
     });
 
     suite("_onSheetResponse", function () {


### PR DESCRIPTION
- always starting refresh timer after firing `rise-google-sheet-error`
- unit test added
- feature version bump
