### PR TITLE
Adding required apikey attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,44 @@
 
 ## Introduction
 
-`rise-google-sheet` is a Polymer Web Component that works with [Rise Vision](https://www.risevision.com/), the digital signage management application for [Web Designers](http://risevision.com/web-designers). It retrieves data from a Google Sheet specified by key. It uses the cell-based feed feature of the [Google Sheets API](https://developers.google.com/google-apps/spreadsheets/) where each entry represents a single cell.
+`rise-google-sheet` is a Polymer Web Component that works with [Rise Vision](https://www.risevision.com/), the digital signage management application for [Web Designers](http://risevision.com/web-designers). It uses  the [Google Sheets API](https://developers.google.com/google-apps/spreadsheets/) to access and retrieve the values of a Google Sheet specified by key.
 
 The `key` attribute is required which is to identify the Google Sheet you want to target. A spreadsheet's key can be found in the URL when viewing it in Google Docs (e.g. docs.google.com/spreadsheets/d/< KEY >/edit#gid=0).
 
-Optionally, the `tab-id` attribute allows for specifying a particular worksheet tab in the spreadsheet. For example, the first tab would be `tab-id="1"`.
+The `apikey` attribute is required which is to identify the request being sent to the Google Sheets API. Requests to the Google Sheets API for public data must be accompanied by this identifier. To learn more about acquiring an API key see [Acquiring and using an API key](https://developers.google.com/sheets/guides/authorizing#APIKey).
 
-The specified feed is periodically retrieved if the `refresh` attribute is set, although a minimum refresh time of 10 seconds is enforced.
+The `sheet` attribute is also a required attribute which is the name of the sheet to target in a spreadsheet. For example, by default "Sheet1" is the name of the first sheet in a new google spreadsheet.
+
+The data is periodically retrieved if the `refresh` attribute is set, although a minimum refresh time of 1 minute is enforced.
 
 ### Range
-`rise-google-sheet` allows for fetching specific rows or columns from a worksheet by providing several attributes to specify the range of cells you want to retrieve.
+`rise-google-sheet` allows for fetching specific values from a worksheet by providing a `range` attribute where the value must be in A1 notation. This is a string like A1:B2, that refers to a group of cells in the spreadsheet.
 
-For example, to retrieve cells for every row after the first row, and only in the fourth column, add the following attributes below:
-
-```
-<rise-google-sheet key="abc123" min-row="2" min-column="4" max-column="4"></rise-google-sheet>
-```
-
-### Empty cells
-Optionally, the `return-empty` attribute allows for retrieving all cell data in a worksheet including empty cells. This is helpful if perhaps you want to visualize a table with the data and it's important that empty cells are included in the response to accurately populate the table with the data. 
-
-Please note that using `return-empty` will return all empty cells, including the excess columns and rows in your worksheet. If this is not desired then you can workaround this by deleting the excess columns and rows from your worksheet. Alternatively, use the range attributes to specify exactly which cells are required.
-
-For example, to retrieve cells for columns 1-5 and rows 2-10 **and** include empty cells:
+For example, A1:B2 refers to the first two cells in the top two rows of the targeted sheet and would be used like below:
 
 ```
-<rise-google-sheet key="abc123" max-column="5" min-row="2" max-row="10" return-empty="true"></rise-google-sheet>
+<rise-google-sheet key="abc123" apikey="def456" sheet="Sheet1" range="A1:B2"></rise-google-sheet>
 ```
+
+### Dimension
+Optionally, the `dimension` attribute allows for specifying the major dimension that results should use. Options are "ROWS" or "COLUMNS". By default the "ROWS" value is applied. 
+
+For example, if the spreadsheet data is: A1=1,B1=2,A2=3,B2=4, then the below will return [[1,2],[3,4]]:
+
+```
+<rise-google-sheet key="abc123" apikey="def456" sheet="Sheet1" dimension="ROWS"></rise-google-sheet>
+```
+
+Whereas the below will return [[1,3],[2,4]]:
+
+```
+<rise-google-sheet key="abc123" apikey="def456" sheet="Sheet1" dimension="COLUMNS"></rise-google-sheet>
+```
+
+### Render
+Optionally, the `render` attribute can be used to specify how values should be represented in the output. By default, the "FORMATTED_VALUE" is applied which means values will be calculated and formatted in the reply according to the cell's formatting.
+
+For a list of options and detail on the use of each see [ValueRenderOption](https://developers.google.com/sheets/reference/rest/v4/ValueRenderOption).
 
 ## Usage
 To use the Google Sheet Web Component, you should first install it using Bower:
@@ -48,7 +59,8 @@ Next, construct your HTML page. You should include `webcomponents-lite.min.js` b
   <body>
     <rise-google-sheet
       key="abc123"
-      min-row="2"
+      apikey="def456"
+      sheet="Sheet1"
       refresh="30"></rise-google-sheet>
 
     <script>
@@ -58,8 +70,8 @@ Next, construct your HTML page. You should include `webcomponents-lite.min.js` b
 
         // Respond to events it fires.
         sheet.addEventListener('rise-google-sheet-response', function(e) {
-          if (e.detail && e.detail.cells) {
-            console.log(e.detail.cells); // Array of cell objects
+          if (e.detail && e.detail.results) {
+            console.log(e.detail.results); // Array of values
           }
         });
 
@@ -70,9 +82,7 @@ Next, construct your HTML page. You should include `webcomponents-lite.min.js` b
 </html>
 ```
 
-`rise-google-sheet` returns an Array of cell objects that the Sheets API has provided. It uses the cell-based feed feature of the API where each entry represents a single cell.
-
-For more detail on the format of cell objects see ["Working with cell-based feeds"](https://developers.google.com/google-apps/spreadsheets/#working_with_cell-based_feeds_1).
+`rise-google-sheet` returns an Array of values that the Sheets API has provided.
 
 ## Documentation
 For further documentation on `rise-google-sheet` attributes, methods, usage, and a comprehensive demo, please see [here](http://rise-vision.github.io/rise-google-sheet).
@@ -106,8 +116,8 @@ To make changes to the web component, you'll first need to install the dependenc
 
 The web components can now be installed by executing the following commands in Terminal:
 ```
-git clone https://github.com/Rise-Vision/web-component-rise-google-sheet.git
-cd web-component-rise-google-sheet
+git clone https://github.com/Rise-Vision/rise-google-sheet.git
+cd rise-google-sheet
 npm install
 bower install
 ```

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],
@@ -26,9 +26,6 @@
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "pure": "^0.6.0",
-    "rise-page": "https://github.com/Rise-Vision/rise-page.git",
-    "rise-playlist": "https://github.com/Rise-Vision/rise-playlist.git",
-    "rise-playlist-item": "https://github.com/Rise-Vision/rise-playlist-item.git",
     "web-component-tester": "*"
   }
 }

--- a/demo/demo-basic.html
+++ b/demo/demo-basic.html
@@ -12,6 +12,13 @@
 
 <p>An example of <code>&lt;rise-google-sheet&gt;</code>:</p>
 
+<p>Enter your API key and click "Submit"</p>
+
+<form name="apikey">
+  <input type="text" style="width: 300px;" name="key" id="key" maxlength="100">
+  <input type="button" name="btn" value="Submit" />
+</form>
+
 <rise-google-sheet id="googleSheet"
                    key="1P5kJXEszMm-vNpaPeQ6I-rD9SGM_gqacIrHMOUrQx_I"
                    sheet="Cars"></rise-google-sheet>
@@ -20,10 +27,27 @@
   (function () {
     "use strict";
 
+    function go(apiKey) {
+      var googleSheet = document.getElementById("googleSheet");
+
+      googleSheet.setAttribute("apiKey", apiKey);
+
+      googleSheet.go();
+    }
+
     function webComponentsReady() {
       window.removeEventListener("WebComponentsReady", webComponentsReady);
 
-      var googleSheet = document.getElementById("googleSheet");
+      var googleSheet = document.getElementById("googleSheet"),
+        formBtn = document.querySelector("input[name='btn']"),
+        apiKeyInput = document.querySelector("input[name='key']");
+
+      //add event listener
+      formBtn.addEventListener("click", function() {
+        if (apiKeyInput.value !== "") {
+          go(apiKeyInput.value);
+        }
+      });
 
       googleSheet.addEventListener("rise-google-sheet-response", function (e) {
         console.log(e.detail.results);
@@ -32,8 +56,6 @@
       googleSheet.addEventListener("rise-google-sheet-error", function (e) {
         console.log(e.detail);
       });
-
-      googleSheet.go();
 
     }
 

--- a/demo/demo-playlist.js
+++ b/demo/demo-playlist.js
@@ -44,34 +44,16 @@ var DemoPlaylist = function () {
     }
   }
 
-  function _getNumOfColumns(cells) {
-    var columns = [],
-      found, val;
-
-    for (var i = 0; i < cells.length; i += 1) {
-      val = parseInt(cells[i].gs$cell.col, 10);
-      found = columns.some(function (col) {
-        return col === val;
-      });
-
-      if (!found) {
-        columns.push(val);
-      }
-    }
-
-    return columns.length;
-  }
-
-  function _applyHeaderRow(cells, numOfColumns) {
+  function _applyHeaderRow(headerValues) {
     var thead = document.querySelector("thead tr"),
       fragment = document.createDocumentFragment(),
       titles = [],
       th;
 
-    // loop through cells data and construct table header markup
-    for (var i = 0; i < numOfColumns; i += 1) {
+    // loop through first row column values and construct table header markup
+    for (var i = 0; i < headerValues.length; i += 1) {
       th = document.createElement("th");
-      th.innerHTML = (cells[i]) ?  cells[i].gs$cell.$t : "";
+      th.innerHTML = headerValues[i];
 
       titles.push(th);
     }
@@ -83,16 +65,16 @@ var DemoPlaylist = function () {
     thead.appendChild(fragment);
   }
 
-  function _getRow(cells, numOfColumns, index) {
+  function _getRow(rowValues) {
     var fragment = document.createDocumentFragment(),
       contents = [],
       tr = document.createElement("tr"),
       td;
 
-    // loop through cells data and construct row markup
-    for (var i = index; i < (index + numOfColumns); i += 1) {
+    // loop through values and construct row markup
+    for (var i = 0; i < rowValues.length; i += 1) {
       td = document.createElement("td");
-      td.innerHTML = (cells[i]) ? cells[i].gs$cell.$t : "";
+      td.innerHTML = rowValues[i];
 
       contents.push(td);
     }
@@ -106,17 +88,16 @@ var DemoPlaylist = function () {
     return fragment;
   }
 
-  function _build(cells) {
-    var numOfColumns = _getNumOfColumns(cells),
-      tbody = document.getElementsByTagName("tbody"),
+  function _build(results) {
+    var tbody = document.getElementsByTagName("tbody"),
       fragment = document.createDocumentFragment(),
       rows = [],
       row;
 
-    _applyHeaderRow(cells, numOfColumns);
+    _applyHeaderRow(results[0]);
 
-    for (var i = numOfColumns; i < cells.length; i += numOfColumns) {
-      row = _getRow(cells, numOfColumns, i);
+    for (var i = 1; i < results.length; i += 1) {
+      row = _getRow(results[i]);
       rows.push(row);
     }
 
@@ -130,9 +111,9 @@ var DemoPlaylist = function () {
     _ready();
   }
 
-  function init() {
+  function init(apiKey) {
     // reference to rise-google-sheet element
-    var googleSheet = document.querySelector("#googleSheet");
+    var googleSheet = document.querySelector("rise-google-sheet");
 
     // register for the "rise-google-sheet-response" event that rise-google-sheet fires
     googleSheet.addEventListener("rise-google-sheet-response", function(e) {
@@ -140,9 +121,11 @@ var DemoPlaylist = function () {
       _clear();
 
       // build the table content with the worksheet data
-      _build(e.detail.cells);
+      _build(e.detail.results);
 
     });
+
+    googleSheet.setAttribute("apiKey", apiKey);
 
     // execute making a request for the Google Sheet data
     googleSheet.go();

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,16 +2,13 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <title>rise-google-sheet Playlist Content Demo</title>
+  <title>rise-google-sheet Demo</title>
 
   <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
 
   <!-- Handy Table styling -->
   <link rel="stylesheet" href="../../pure/tables-min.css">
 
-  <link rel="import" href="../../rise-page/rise-page.html">
-  <link rel="import" href="../../rise-playlist/rise-playlist.html">
-  <link rel="import" href="../../rise-playlist-item/rise-playlist-item.html">
   <link rel="import" href="../rise-google-sheet.html">
 
 </head>
@@ -19,31 +16,28 @@
 
 <p>An example of <code>&lt;rise-google-sheet&gt;</code>:</p>
 
-<rise-page display-id="VGZUDDWYAZHY">
+<p>Enter your API key and click "Submit"</p>
 
-  <rise-playlist id="playlist">
+<form style="margin-bottom: 10px">
+  <input type="text" style="width: 300px;" name="key" id="key" maxlength="100">
+  <input type="button" name="btn" value="Submit" />
+</form>
 
-    <rise-playlist-item>
-      <rise-google-sheet id="googleSheet"
-                         key="1P5kJXEszMm-vNpaPeQ6I-rD9SGM_gqacIrHMOUrQx_I"
-                         max-column="4" max-row="6" return-empty="true">
-        <!-- Example HTML structure -->
-        <table id="sheetTable" class="pure-table pure-table-bordered">
-          <thead>
-          <tr>
-            <!-- dynamically add column header titles -->
-          </tr>
-          </thead>
-          <tbody>
-          <!-- dynamically populate table cells -->
-          </tbody>
-        </table>
-      </rise-google-sheet>
-    </rise-playlist-item>
-
-  </rise-playlist>
-
-</rise-page>
+<rise-google-sheet id="googleSheet"
+                   key="1P5kJXEszMm-vNpaPeQ6I-rD9SGM_gqacIrHMOUrQx_I"
+                   sheet="Cars">
+  <!-- Example HTML structure -->
+  <table id="sheetTable" class="pure-table pure-table-bordered">
+    <thead>
+    <tr>
+      <!-- dynamically add column header titles -->
+    </tr>
+    </thead>
+    <tbody>
+    <!-- dynamically populate table cells -->
+    </tbody>
+  </table>
+</rise-google-sheet>
 
 <!-- Importing javascript which is the logic in building and managing the Google Sheet content -->
 <script type="text/javascript" src="demo-playlist.js"></script>
@@ -55,13 +49,22 @@
     "use strict";
 
     function webComponentsReady() {
+      var formBtn = document.querySelector("input[name='btn']"),
+        apiKeyInput = document.querySelector("input[name='key']");
+
       window.removeEventListener("WebComponentsReady", webComponentsReady);
 
       // new instance of DemoPlaylist object
       var demo = new DemoPlaylist();
 
-      // initialize the content
-      demo.init();
+      //add event listener
+      formBtn.addEventListener("click", function() {
+        if (apiKeyInput.value !== "") {
+          // initialize the content
+          demo.init(apiKeyInput.value);
+        }
+      });
+
     }
 
     window.addEventListener("WebComponentsReady", webComponentsReady);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Rise Vision web component for retrieving Google Sheet data",
   "scripts": {
     "test": "gulp test",

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -8,6 +8,10 @@ The `key` attribute is required which is to identify the Google Spreadsheet you 
 A spreadsheet's key can be found in the URL when viewing it in Google Docs
 (e.g. docs.google.com/spreadsheets/d/< KEY >/edit#gid=0).
 
+The `apikey` attribute is required which is to identify the request being sent to the Google Sheets API.
+Requests to the Google Sheets API for public data must be accompanied by this identifier. To learn more about
+acquiring an API key see [Acquiring and using an API key](https://developers.google.com/sheets/guides/authorizing#APIKey).
+
 The `sheet` attribute is also required which is the name of the specific sheet within the Spreadsheet that you want
 to retrieve values from. (eg. Sheet1)
 
@@ -16,7 +20,7 @@ time of 1 minute is enforced.
 
 #### Example Usage
 
-    <rise-google-sheet key="abc123" sheet="Sheet1" refresh="30"></rise-google-sheet>
+    <rise-google-sheet key="abc123" apikey="def456" sheet="Sheet1" refresh="30"></rise-google-sheet>
 
     <script>
       var sheet = document.querySelector('rise-google-sheet');
@@ -38,7 +42,7 @@ time of 1 minute is enforced.
 
 For example, to retrieve all values within cells A1 to B2 of the worksheet:
 
-    <rise-google-sheet key="abc123" sheet="Sheet1" range="A1:B2"></rise-google-sheet>
+    <rise-google-sheet key="abc123" apikey="def456" sheet="Sheet1" range="A1:B2"></rise-google-sheet>
 
 #### Dimension
 
@@ -74,8 +78,6 @@ the values that can be provided in this attribute and their impact, see [Google 
 
     var API_BASE_URL = "https://sheets.googleapis.com/v4/spreadsheets/";
 
-    var API_KEY = "AIzaSyBXxVK_IOV7LNQMuVVo_l7ZvN53ejN86zY";
-
     var LOCAL_STORAGE_BASE_NAME = "risesheet";
 
     function supportsLocalStorage() {
@@ -95,6 +97,14 @@ the values that can be provided in this attribute and their impact, see [Google 
          * the document in Google Docs (e.g. docs.google.com/spreadsheets/d/<KEY>).
          */
         key: {
+          type: String,
+          value: ""
+        },
+
+        /**
+         * An api key must be provided to make the request for public data using the Sheets API (v4).
+         */
+        apikey: {
           type: String,
           value: ""
         },
@@ -289,7 +299,7 @@ the values that can be provided in this attribute and their impact, see [Google 
         var params = {};
 
         // required to obtain public data
-        params.key = API_KEY;
+        params.key = this.apikey;
 
         params.majorDimension = this.dimension;
 
@@ -311,8 +321,8 @@ the values that can be provided in this attribute and their impact, see [Google 
        *
        */
       go: function() {
-        // key is required, don't make request if missing 'key' or if a previous request is pending
-        if (this.key === "" || this.sheet === "" || this._requestPending) {
+        // key, apikey, and sheet are required, don't make request if any are missing or if a previous request is pending
+        if (this.key === "" || this.apikey === "" || this.sheet === "" || this._requestPending) {
           return;
         }
 

--- a/test/rise-google-sheet-integration.html
+++ b/test/rise-google-sheet-integration.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 
-<rise-google-sheet id="request" key="abc123" sheet="Sheet1"></rise-google-sheet>
+<rise-google-sheet id="request" key="abc123" apikey="def456" sheet="Sheet1"></rise-google-sheet>
 
 <script src="data/sheet.js"></script>
 <script src="data/error.js"></script>

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 
-<rise-google-sheet id="request" key="abc123" sheet="Sheet1"></rise-google-sheet>
+<rise-google-sheet id="request" key="abc123" apikey="def456" sheet="Sheet1"></rise-google-sheet>
 
 <script src="data/sheet.js"></script>
 <script src="data/error.js"></script>
@@ -162,12 +162,13 @@
     suite("_getParams", function() {
       var params,
         standardParams = {
-          "key": "AIzaSyBXxVK_IOV7LNQMuVVo_l7ZvN53ejN86zY",
+          "key": "def456",
           "majorDimension": "ROWS",
           "valueRenderOption": "FORMATTED_VALUE"
         };
 
       teardown(function() {
+        sheetRequest.apikey = "def456";
         sheetRequest.dimension = "ROWS";
         sheetRequest.render = "FORMATTED_VALUE";
       });
@@ -176,6 +177,16 @@
         params = sheetRequest._getParams();
 
         assert.deepEqual(params, standardParams);
+      });
+
+      test("should return an object that applies 'apikey` attribute value", function () {
+        sheetRequest.apikey = "test";
+
+        params = sheetRequest._getParams();
+
+        assert.property(params, "key");
+        assert.isString(params["key"]);
+        assert.equal(params["key"], "test");
       });
 
       test("should return an object that applies 'dimension' attribute value", function () {
@@ -243,6 +254,7 @@
 
       teardown(function() {
         sheetRequest.key = "abc123";
+        sheetRequest.apikey = "def456";
         sheetRequest.sheet = "Sheet1";
         sheetRequest._requestPending = false;
         sheetRequest.$.sheet.generateRequest.restore();
@@ -264,6 +276,13 @@
         assert.equal(requestStub.callCount, 0);
       });
 
+      test("should not make call to generate request without a value for 'apikey'", function () {
+        sheetRequest.apikey = "";
+        sheetRequest.go();
+
+        assert.equal(requestStub.callCount, 0);
+      });
+
       test("should ensure the correct url is provided in request to Sheets API", function () {
         sheetRequest.go();
 
@@ -274,7 +293,7 @@
         sheetRequest.go();
 
         assert.deepEqual(sheetRequest.$.sheet.params, {
-          "key": "AIzaSyBXxVK_IOV7LNQMuVVo_l7ZvN53ejN86zY",
+          "key": "def456",
           "majorDimension": "ROWS",
           "valueRenderOption": "FORMATTED_VALUE"
         });


### PR DESCRIPTION
- Removing hardcoded API key and enforcing a required `apikey` attribute to use when making request to API
- Updated README
- Unit and integration tests revised
- Revised demos to force entry of api key and removed use of other `rise-` components as they were causing visibility issues of the content in the main demo
