### PR TITLE
Reducing API requests by use of localStorage and timestamp

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "moment": "^2.14.0",
     "pure": "^0.6.0",
     "web-component-tester": "*"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Rise Vision web component for retrieving Google Sheet data",
   "scripts": {
     "test": "gulp test",

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -1,6 +1,8 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-ajax/iron-ajax.html">
 
+<script src="../moment/moment.js"></script>
+
 <!--
 `rise-google-sheet` is a web component that retrieves values from a Google Sheet specified by key and sheet name.
 
@@ -71,7 +73,7 @@ the values that can be provided in this attribute and their impact, see [Google 
 
 <script>
   (function() {
-    /* global Polymer */
+    /* global Polymer, moment */
     /* jshint newcap: false */
 
     "use strict";
@@ -164,6 +166,10 @@ the values that can be provided in this attribute and their impact, see [Google 
 
       _requestPending: false,
 
+      _refreshPending: false,
+
+      _initialGo: true,
+
       // Element Behavior
 
       /**
@@ -194,9 +200,13 @@ the values that can be provided in this attribute and their impact, see [Google 
       },
 
       _setCachedData: function (data) {
+        var cacheObj = {};
+
         if (supportsLocalStorage()) {
+          cacheObj.data = data;
+          cacheObj.timestamp = moment().format();
           try {
-            localStorage.setItem(this._getLocalStorageKey(), JSON.stringify(data));
+            localStorage.setItem(this._getLocalStorageKey(), JSON.stringify(cacheObj));
           } catch(e) {
             console.warn(e.message);
           }
@@ -211,6 +221,7 @@ the values that can be provided in this attribute and their impact, see [Google 
 
         if (!isNaN(this.refresh) && this.refresh !== 0) {
           this.debounce("refresh", function () {
+            self._refreshPending = true;
             refreshFn.call(self);
           }, this.refresh * 60000);
         }
@@ -232,9 +243,9 @@ the values that can be provided in this attribute and their impact, see [Google 
         var cachedData = this._getCachedData();
 
         if (cachedData) {
-          this._setResults(cachedData.results);
+          this._setResults(cachedData.data.results);
 
-          this.fire("rise-google-sheet-response", cachedData);
+          this.fire("rise-google-sheet-response", cachedData.data);
         }
         else {
           this.fire("rise-google-sheet-error", resp);
@@ -316,16 +327,7 @@ the values that can be provided in this attribute and their impact, see [Google 
         return API_BASE_URL + this.key + "/values/" + this.sheet + this._getRange();
       },
 
-      /**
-       * Performs a request to obtain the Google Sheet data
-       *
-       */
-      go: function() {
-        // key, apikey, and sheet are required, don't make request if any are missing or if a previous request is pending
-        if (this.key === "" || this.apikey === "" || this.sheet === "" || this._requestPending) {
-          return;
-        }
-
+      _makeRequest: function() {
         // set flag to prevent further requests in case go() function is called before prior request responds
         this._requestPending = true;
 
@@ -334,6 +336,62 @@ the values that can be provided in this attribute and their impact, see [Google 
         this.$.sheet.params = this._getParams();
 
         this.$.sheet.generateRequest();
+      },
+
+      /**
+       * Performs a request to obtain the Google Sheet data
+       *
+       */
+      go: function() {
+        var cachedData = this._getCachedData(),
+          refreshVal = parseInt(this.refresh, 10),
+          makeRequestFn = this._makeRequest,
+          self = this,
+          then, now, diff;
+
+        // key, apikey, and sheet are required, don't make request if any are missing or if a previous request is pending
+        if (this.key === "" || this.apikey === "" || this.sheet === "" || this._requestPending) {
+          return;
+        }
+
+        if (this._refreshPending || !cachedData) {
+          // refresh timer completed or there is no cached data available, make the request
+          this._refreshPending = false;
+          this._makeRequest();
+        }
+        else {
+          if (this._initialGo) {
+            this._initialGo = false;
+
+            // first time component is executing go()
+
+            if (!isNaN(refreshVal) && refreshVal !== 0) {
+              then = moment(cachedData.timestamp);
+              now = moment();
+              diff = now.diff(then, "minutes");
+
+              // compare refresh value to amount of time that has passed since last timestamp in cached data
+
+              if (diff >= refreshVal) {
+                // more time has gone by than the assigned refresh value, make the request
+                this._makeRequest();
+                return;
+              }
+              else {
+                // start a refresh timer with the remaining refresh time left as the interval
+                this.debounce("refresh", function () {
+                  makeRequestFn.call(self);
+                }, (refreshVal - diff) * 60000);
+              }
+            }
+          }
+
+          this._setResults(cachedData.data.results);
+
+          // provide cached data for the response
+          this.fire("rise-google-sheet-response", cachedData.data);
+        }
+
       }
 
     });

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -128,6 +128,13 @@
       });
 
       test("should fire rise-google-sheet-response, set results property, and save to localStorage", function(done) {
+        var cachedData = {
+          data: {
+            results: sheetData.values
+          },
+          timestamp: ""
+        };
+
         listener = function(response) {
           responded = true;
 
@@ -140,7 +147,7 @@
         sheetRequest._onSheetResponse(e, resp);
 
         assert.deepEqual(sheetRequest.results, resp.response.values, "results property is set correctly");
-        assert.deepEqual(JSON.parse(localStorage.getItem(sheetRequest._getLocalStorageKey())), {results: sheetData.values},
+        assert.deepEqual(JSON.parse(localStorage.getItem(sheetRequest._getLocalStorageKey())).data, {results: sheetData.values},
           "localStorage saved data correctly");
         assert.isTrue(responded);
 
@@ -241,10 +248,6 @@
       });
     });
 
-    teardown(function() {
-      sheetRequest.range = "";
-    });
-
     suite("go", function () {
       var requestStub;
 
@@ -256,8 +259,12 @@
         sheetRequest.key = "abc123";
         sheetRequest.apikey = "def456";
         sheetRequest.sheet = "Sheet1";
+        sheetRequest.refresh = "";
         sheetRequest._requestPending = false;
+        sheetRequest._refreshPending = false;
         sheetRequest.$.sheet.generateRequest.restore();
+
+        localStorage.removeItem(sheetRequest._getLocalStorageKey());
       });
 
       test("should not make call to generate request without a value for 'key'", function () {
@@ -299,7 +306,7 @@
         });
       });
 
-      test("should generate request to Sheets API", function () {
+      test("should generate request to Sheets API when no cached data available", function () {
         sheetRequest.go();
 
         assert(requestStub.calledOnce);
@@ -312,6 +319,37 @@
 
         assert(requestStub.calledOnce);
       });
+
+      test("should generate request if refresh is pending", function () {
+        localStorage.setItem(sheetRequest._getLocalStorageKey(), JSON.stringify({data: {results: sheetData.values}, timestamp: ""}));
+        sheetRequest.refresh = 5;
+        sheetRequest._refreshPending = true;
+
+        sheetRequest.go();
+
+        assert(requestStub.calledOnce);
+      });
+
+      test("should fire rise-google-sheet-response with cached data when refresh not pending and cached data available", function(done) {
+        listener = function(response) {
+          responded = true;
+
+          assert.deepEqual(response.detail.results, sheetData.values, "detail.results property exists");
+
+          sheetRequest.removeEventListener("rise-google-sheet-response", listener);
+        };
+
+        localStorage.setItem(sheetRequest._getLocalStorageKey(), JSON.stringify({data: {results: sheetData.values}, timestamp: ""}));
+
+        sheetRequest.addEventListener("rise-google-sheet-response", listener);
+        sheetRequest.go();
+
+        assert.equal(requestStub.callCount, 0);
+        assert.isTrue(responded);
+
+        done();
+      });
+
     });
 
     suite("_startTimer", function() {
@@ -332,6 +370,8 @@
         sheetRequest._startTimer();
 
         clock.tick(1800000);
+
+        assert.isTrue(sheetRequest._refreshPending);
         assert(timerStub.calledOnce);
 
         sheetRequest.go.restore();
@@ -366,6 +406,15 @@
         assert.isString(value);
       });
 
+      test("should ensure timestamp is added to cached data", function () {
+        sheetRequest._setCachedData({results: sheetData.values});
+
+        var value = localStorage.getItem(sheetRequest._getLocalStorageKey());
+
+        assert.property(JSON.parse(value), "timestamp");
+        assert.isString(JSON.parse(value).timestamp, "timestamp");
+      });
+
     });
 
     suite("_getCachedData", function () {
@@ -382,7 +431,7 @@
       });
 
       test("Should ensure value returned has been parsed as JSON", function () {
-        localStorage.setItem(sheetRequest._getLocalStorageKey(), JSON.stringify({results: sheetData.values}));
+        localStorage.setItem(sheetRequest._getLocalStorageKey(), JSON.stringify({data: {results: sheetData.values}, timestamp: ""}));
 
         value = sheetRequest._getCachedData();
 
@@ -414,7 +463,7 @@
         };
 
         // ensure cached data exists
-        localStorage.setItem(sheetRequest._getLocalStorageKey(), JSON.stringify({results:sheetData.values}));
+        localStorage.setItem(sheetRequest._getLocalStorageKey(), JSON.stringify({data: {results: sheetData.values}, timestamp: ""}));
 
         sheetRequest.addEventListener("rise-google-sheet-response", listener);
         sheetRequest._handleNoNetwork(resp);


### PR DESCRIPTION
- `setCachedData` now stores a timestamp along with the data
- `go()` always makes an API request for data if no cached data available or a refresh is pending
- if cached data available and a refresh is not pending, `go()` fires `rise-google-sheet-response` with cached data
- When it's the first time that `go()` is called and there's cached data available, the timestamp is compared with current time and measured against refresh value to conditionally either make a request or start a timer based on the amount of refresh time remaining
- Unit tests revised and added
- Minor patch version bump
