### PR TITLE
Adding support for handling quota exceeded

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Rise Vision web component for retrieving Google Sheet data",
   "scripts": {
     "test": "gulp test",

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -176,7 +176,7 @@ the values that can be provided in this attribute and their impact, see [Google 
        * Fired when a response is received.
        *
        * @param {Object} detail
-       * @param {Object} detail.data The data returned by the Google Sheets API
+       * @param {Object} detail.results The array of sheet values returned by the Google Sheets API
        * @event rise-google-sheet-response
        */
 
@@ -184,6 +184,14 @@ the values that can be provided in this attribute and their impact, see [Google 
        * Fired when an error is received.
        *
        * @event rise-google-sheet-error
+       */
+
+      /**
+       * Fired when the API key has exceeded its quota for daily requests.
+       *
+       * @param {Object} detail
+       * @param {Object} detail.results The cached array of sheet values if data has been cached
+       * @event rise-google-sheet-quota
        */
 
       _getLocalStorageKey: function () {
@@ -239,6 +247,20 @@ the values that can be provided in this attribute and their impact, see [Google 
         return response;
       },
 
+      _handleQuotaExceeded: function () {
+        var cachedData = this._getCachedData();
+
+        if (cachedData) {
+          this._setResults(cachedData.data.results);
+        }
+
+        this.fire("rise-google-sheet-quota", (cachedData) ? cachedData.data : null);
+
+        this._requestPending = false;
+        this._startTimer();
+
+      },
+
       _handleNoNetwork: function (resp) {
         var cachedData = this._getCachedData();
 
@@ -259,26 +281,34 @@ the values that can be provided in this attribute and their impact, see [Google 
         // in case there are other instances of rise-google-sheet
         e.stopPropagation();
 
-        if (resp.request && resp.request.status === 0) {
-          this._handleNoNetwork(resp);
-        }
-        else {
-          // reset the value of cells
-          this._setResults([]);
+        if (resp.request) {
+          switch (resp.request.status) {
+            case 0:
+              this._handleNoNetwork(resp);
+              break;
+            case 429:
+              this._handleQuotaExceeded();
+              break;
+            default:
+              // reset the value of cells
+              this._setResults([]);
 
-          // if cached data exists, remove it
-          if (this._getCachedData()) {
-            try {
-              localStorage.removeItem(this._getLocalStorageKey());
-            } catch (ex) {
-              console.warn(ex.message);
-            }
+              // if cached data exists, remove it
+              if (this._getCachedData()) {
+                try {
+                  localStorage.removeItem(this._getLocalStorageKey());
+                } catch (ex) {
+                  console.warn(ex.message);
+                }
+              }
+
+              this.fire("rise-google-sheet-error", resp);
+
+              this._requestPending = false;
+              this._startTimer();
+
+              break;
           }
-
-          this.fire("rise-google-sheet-error", resp);
-
-          this._requestPending = false;
-          this._startTimer();
         }
 
       },

--- a/test/rise-google-sheet-integration.html
+++ b/test/rise-google-sheet-integration.html
@@ -73,6 +73,30 @@
         server.respond();
       });
 
+      test("should notify when API has exceeded its quota", function (done) {
+        responseHandler = function(response) {
+
+          assert.deepEqual(response.detail, {});
+
+          sheetRequest.removeEventListener("rise-google-sheet-quota", responseHandler);
+          done();
+        };
+
+        sheetRequest.addEventListener("rise-google-sheet-quota", responseHandler);
+
+        server.respondWith([429, {}, JSON.stringify({
+          "error": {
+            "message": "The request failed with status code: 429"
+          },
+          "request": {
+            "status": 429
+          }
+        })]);
+
+        sheetRequest.go();
+        server.respond();
+      });
+
     });
 
     suite("offline cached data", function() {

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -81,6 +81,20 @@
         sheetRequest._handleNoNetwork.restore();
       });
 
+      test("should call _handleQuotaExceeded if request status is 429", function () {
+        var quotaStub = sinon.stub(sheetRequest, "_handleQuotaExceeded");
+
+        sheetRequest._onSheetError(e, {
+          "request": {
+            "status": 429
+          }
+        });
+
+        assert.isTrue(quotaStub.calledOnce);
+
+        sheetRequest._handleQuotaExceeded.restore();
+      });
+
       test("should remove item from localStorage if it exists", function () {
         localStorage.setItem(sheetRequest._getLocalStorageKey(), JSON.stringify({results: sheetData.values}));
 
@@ -484,6 +498,52 @@
 
         sheetRequest.addEventListener("rise-google-sheet-error", listener);
         sheetRequest._handleNoNetwork(resp);
+
+        assert.isTrue(responded);
+
+        done();
+      });
+
+    });
+
+    suite("_handleQuotaExceeded", function () {
+      teardown(function() {
+        sheetRequest._setResults([]);
+        localStorage.removeItem(sheetRequest._getLocalStorageKey());
+      });
+
+      test("should fire rise-google-sheet-quota", function (done) {
+        listener = function(response) {
+          responded = true;
+
+          assert.deepEqual(response.detail, {});
+
+          sheetRequest.removeEventListener("rise-google-sheet-quota", listener);
+        };
+
+        sheetRequest.addEventListener("rise-google-sheet-quota", listener);
+        sheetRequest._handleQuotaExceeded();
+
+        assert.isTrue(responded);
+
+        done();
+      });
+
+      test("should fire rise-google-sheet-quota and provide cached data when it exists", function (done) {
+        listener = function(response) {
+          responded = true;
+
+          assert.property(response.detail, "results", "detail.results property exists");
+          assert.deepEqual(response.detail.results, sheetData.values);
+
+          sheetRequest.removeEventListener("rise-google-sheet-quota", listener);
+        };
+
+        // ensure cached data exists
+        localStorage.setItem(sheetRequest._getLocalStorageKey(), JSON.stringify({data: {results: sheetData.values}, timestamp: ""}));
+
+        sheetRequest.addEventListener("rise-google-sheet-quota", listener);
+        sheetRequest._handleQuotaExceeded();
 
         assert.isTrue(responded);
 


### PR DESCRIPTION
- Checks for a 429 status in server response
- Fires `rise-google-sheet-quota` when 429 response and provides cached data if it exists
- Unit and integration tests added
- Feature version bump
