### PR TITLE
Adding sheet to local storage key

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Rise Vision web component for retrieving Google Sheet data",
   "scripts": {
     "test": "gulp test",

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -195,7 +195,8 @@ the values that can be provided in this attribute and their impact, see [Google 
        */
 
       _getLocalStorageKey: function () {
-        return LOCAL_STORAGE_BASE_NAME + "_" + this.key + (this.range === "" ? "" : "_" + this.range);
+        return LOCAL_STORAGE_BASE_NAME + "_" + this.key + "_" + this.sheet +
+          (this.range === "" ? "" : "_" + this.range);
       },
 
       _getCachedData: function () {

--- a/test/rise-google-sheet-integration.html
+++ b/test/rise-google-sheet-integration.html
@@ -35,7 +35,7 @@
     });
 
     setup(function() {
-      localStorage.removeItem("risesheet_" + sheetRequest.key); // clear localStorage
+      localStorage.removeItem("risesheet_" + sheetRequest.key + "_" + sheetRequest.sheet); // clear localStorage
     });
 
     suite("request data", function() {

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -42,14 +42,14 @@
         sheetRequest.range = "";
       });
 
-      test("should return correct local storage key using unique sheet key", function () {
-        assert.equal(sheetRequest._getLocalStorageKey(), "risesheet_abc123");
+      test("should return correct local storage key using unique and required sheet key and name", function () {
+        assert.equal(sheetRequest._getLocalStorageKey(), "risesheet_abc123_Sheet1");
       });
 
       test("should return correct local storage key using unique sheet key and range", function () {
         sheetRequest.range = "A1:C3";
 
-        assert.equal(sheetRequest._getLocalStorageKey(), "risesheet_abc123_A1:C3");
+        assert.equal(sheetRequest._getLocalStorageKey(), "risesheet_abc123_Sheet1_A1:C3");
       });
 
     });


### PR DESCRIPTION
- `sheet` value used in the local storage key name
- unit test added
- Minor patch version bump
