### PR TITLE
Encoding sheet value for API request

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Rise Vision web component for retrieving Google Sheet data",
   "scripts": {
     "test": "gulp test",

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -355,7 +355,7 @@ the values that can be provided in this attribute and their impact, see [Google 
       },
 
       _getUrl: function() {
-        return API_BASE_URL + this.key + "/values/" + this.sheet + this._getRange();
+        return API_BASE_URL + this.key + "/values/" + encodeURIComponent(this.sheet) + this._getRange();
       },
 
       _makeRequest: function() {

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 
-<rise-google-sheet id="request" key="abc123" apikey="def456" sheet="Sheet1"></rise-google-sheet>
+<rise-google-sheet id="request" key="abc123" apikey="def456" sheet="Sheet/1"></rise-google-sheet>
 
 <script src="data/sheet.js"></script>
 <script src="data/error.js"></script>
@@ -43,13 +43,13 @@
       });
 
       test("should return correct local storage key using unique and required sheet key and name", function () {
-        assert.equal(sheetRequest._getLocalStorageKey(), "risesheet_abc123_Sheet1");
+        assert.equal(sheetRequest._getLocalStorageKey(), "risesheet_abc123_Sheet/1");
       });
 
       test("should return correct local storage key using unique sheet key and range", function () {
         sheetRequest.range = "A1:C3";
 
-        assert.equal(sheetRequest._getLocalStorageKey(), "risesheet_abc123_Sheet1_A1:C3");
+        assert.equal(sheetRequest._getLocalStorageKey(), "risesheet_abc123_Sheet/1_A1:C3");
       });
 
     });
@@ -268,7 +268,7 @@
         url = sheetRequest._getUrl();
 
         assert.isString(url);
-        assert.equal(url, "https://sheets.googleapis.com/v4/spreadsheets/abc123/values/Sheet1!B2:F20");
+        assert.equal(url, "https://sheets.googleapis.com/v4/spreadsheets/abc123/values/Sheet%2F1!B2:F20");
       });
     });
 


### PR DESCRIPTION
- To account for special characters like "/" in a sheet name and prevent the API from failing, now encoding the `sheet` value when constructing the API url
- unit tests revised
- minor patch version bump
