### PR TITLE
Adding feature for logging usage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],
@@ -21,6 +21,7 @@
   "dependencies": {
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
+    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git",
     "underscore": "~1.8.2",
     "moment": "^2.14.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
-    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git",
+    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.0",
     "underscore": "~1.8.2",
     "moment": "^2.14.0"
   },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,15 +1,16 @@
 (function (console) {
   "use strict";
 
-  var gulp = require("gulp");
-  var bump = require("gulp-bump");
-  var jshint = require("gulp-jshint");
-  var uglify = require('gulp-uglify');
-  var colors = require("colors");
-  var runSequence = require("run-sequence");
-  var wct = require("web-component-tester").gulp.init(gulp);
   var bower = require("gulp-bower");
+  var bump = require("gulp-bump");
+  var colors = require("colors");
   var del = require("del");
+  var gulp = require("gulp");
+  var jshint = require("gulp-jshint");
+  var htmlreplace = require("gulp-html-replace");
+  var runSequence = require("run-sequence");
+  var uglify = require('gulp-uglify');
+  var wct = require("web-component-tester").gulp.init(gulp);
 
   gulp.task("clean-bower", function(cb){
     del(["./bower_components/**"], cb);
@@ -21,6 +22,19 @@
       .pipe(jshint())
       .pipe(jshint.reporter("jshint-stylish"))
       .pipe(jshint.reporter("fail"));
+  });
+
+  gulp.task("version", function() {
+    var pkg = require("./package.json");
+
+    gulp.src("./rise-google-sheet.html")
+      .pipe(htmlreplace({
+        "version": {
+          src: pkg.version,
+          tpl: "<script>var sheetVersion = \"%s\";</script>"
+        }
+      }, {keepBlockTags: true}))
+      .pipe(gulp.dest("./"));
   });
 
   // ***** Primary Tasks ***** //
@@ -41,7 +55,7 @@
     runSequence("test:local", cb);
   });
 
-  gulp.task("build", function (cb) {
+  gulp.task("build", ["version"], function (cb) {
     runSequence("lint", cb);
   });
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp": "~3.8.10",
     "gulp-bower": "~0.0.10",
     "gulp-bump": "~0.2.0",
+    "gulp-html-replace": "~1.6.1",
     "gulp-uglify": "~1.2.0",
     "gulp-jshint": "~1.10.0",
     "jshint-stylish": "~1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "Rise Vision web component for retrieving Google Sheet data",
   "scripts": {
     "test": "gulp test",

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -73,6 +73,10 @@ the values that can be provided in this attribute and their impact, see [Google 
   </template>
 </dom-module>
 
+<!-- build:version -->
+<script>var sheetVersion = "2.3.0";</script>
+<!-- endbuild -->
+
 <script>
   (function() {
     /* global Polymer, moment */
@@ -430,6 +434,8 @@ the values that can be provided in this attribute and their impact, see [Google 
         if (this._isValidUsage(this.usage)) {
           params.usage_type = this.usage;
         }
+
+        params.version = sheetVersion;
 
         // log usage
         this.$.logger.log(BQ_TABLE_NAME, params);

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-ajax/iron-ajax.html">
+<link rel="import" href="../rise-logger/rise-logger.html">
 
 <script src="../moment/moment.js"></script>
 
@@ -62,6 +63,7 @@ the values that can be provided in this attribute and their impact, see [Google 
 -->
 <dom-module id="rise-google-sheet">
   <template>
+    <rise-logger id="logger"></rise-logger>
     <iron-ajax id="sheet"
                handle-as="json"
                on-response="_onSheetResponse"
@@ -81,6 +83,8 @@ the values that can be provided in this attribute and their impact, see [Google 
     var API_BASE_URL = "https://sheets.googleapis.com/v4/spreadsheets/";
 
     var LOCAL_STORAGE_BASE_NAME = "risesheet";
+
+    var BQ_TABLE_NAME = "component_sheet_events";
 
     function supportsLocalStorage() {
       try {
@@ -154,6 +158,14 @@ the values that can be provided in this attribute and their impact, see [Google 
         },
 
         /**
+         * The optional usage type for Rise Vision logging purposes. Options are "standalone" or "widget"
+         */
+        usage: {
+          type: String,
+          value: ""
+        },
+
+        /**
          * Returns the values from a spreadsheet.
          */
         results: {
@@ -193,6 +205,10 @@ the values that can be provided in this attribute and their impact, see [Google 
        * @param {Object} detail.results The cached array of sheet values if data has been cached
        * @event rise-google-sheet-quota
        */
+
+      _isValidUsage: function(usage) {
+        return usage === "standalone" || usage === "widget";
+      },
 
       _getLocalStorageKey: function () {
         return LOCAL_STORAGE_BASE_NAME + "_" + this.key + "_" + this.sheet +
@@ -400,6 +416,23 @@ the values that can be provided in this attribute and their impact, see [Google 
         this.$.sheet.params = this._getParams();
 
         this.$.sheet.generateRequest();
+      },
+
+      /**
+       * Polymer has finished its initialization. This is the entry point.
+       */
+      ready: function() {
+        var params = {
+          event: "ready"
+        };
+
+        // only include usage_type if it's a valid usage value
+        if (this._isValidUsage(this.usage)) {
+          params.usage_type = this.usage;
+        }
+
+        // log usage
+        this.$.logger.log(BQ_TABLE_NAME, params);
       },
 
       /**

--- a/test/rise-google-sheet-integration.html
+++ b/test/rise-google-sheet-integration.html
@@ -18,9 +18,17 @@
 <script src="data/error.js"></script>
 
 <script>
+
+  var sheetRequest = document.querySelector("#request"),
+    display = "abc123";
+
+  // mock logger getting display id from Rise Cache
+  sinon.stub(sheetRequest.$.logger.$.displayId, "generateRequest", function() {
+    sheetRequest.$.logger._onDisplayIdResponse(null, {response: {displayId: display}});
+  });
+
   suite("rise-google-sheet", function() {
-    var clock, server, responseHandler,
-      sheetRequest = document.querySelector("#request");
+    var clock, server, responseHandler;
 
     // Runs for every suite.
     suiteSetup(function() {

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -19,9 +19,18 @@
 <script src="../node_modules/widget-tester/mocks/localStorage-mock.js"></script>
 
 <script>
+
+  var sheetRequest = document.querySelector("#request"),
+    display = "abc123";
+
+  // mock logger getting display id from Rise Cache
+  sinon.stub(sheetRequest.$.logger.$.displayId, "generateRequest", function() {
+    sheetRequest.$.logger._onDisplayIdResponse(null, {response: {displayId: display}});
+  });
+
   suite("rise-google-sheet", function () {
-    var clock, responded, listener,
-      sheetRequest = document.querySelector("#request");
+    var clock, responded, listener;
+
 
     suiteSetup(function() {
       clock = sinon.useFakeTimers();
@@ -34,6 +43,19 @@
     setup(function() {
       responded = false;
       localStorage.removeItem("risesheet_" + sheetRequest.key); // clear localStorage
+    });
+
+    suite("_isValidUsage", function () {
+
+      test("should return true when 'standalone' or 'widget'", function () {
+        assert.isTrue(sheetRequest._isValidUsage("widget"));
+        assert.isTrue(sheetRequest._isValidUsage("standalone"));
+      });
+
+      test("should return false when invalid", function () {
+        assert.isFalse(sheetRequest._isValidUsage("test"));
+      });
+
     });
 
     suite("_getLocalStorageKey", function () {
@@ -632,6 +654,30 @@
         done();
       });
 
+    });
+
+    suite("ready", function() {
+      var logStub;
+
+      suiteSetup(function() {
+        logStub = sinon.stub(sheetRequest.$.logger, "log");
+      });
+
+      suiteTeardown(function() {
+        logStub.restore();
+        sheetRequest.usage = "";
+      });
+
+      test("should log usage", function () {
+        sheetRequest.ready();
+        assert.isTrue(logStub.calledWith("component_sheet_events", {"event": "ready"}));
+      });
+
+      test("should log usage and include 'usage_type'", function() {
+        sheetRequest.usage = "widget";
+        sheetRequest.ready();
+        assert.isTrue(logStub.calledWith("component_sheet_events", {"event": "ready", "usage_type": "widget"}));
+      });
     });
 
   });

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -659,24 +659,26 @@
     suite("ready", function() {
       var logStub;
 
-      suiteSetup(function() {
+      setup(function() {
         logStub = sinon.stub(sheetRequest.$.logger, "log");
       });
 
-      suiteTeardown(function() {
+      teardown(function() {
         logStub.restore();
         sheetRequest.usage = "";
       });
 
       test("should log usage", function () {
         sheetRequest.ready();
-        assert.isTrue(logStub.calledWith("component_sheet_events", {"event": "ready"}));
+        assert.equal(logStub.args[0][0],"component_sheet_events");
+        assert.include(JSON.stringify(logStub.args[0][1]),"{\"event\":\"ready\",\"version\":");
       });
 
       test("should log usage and include 'usage_type'", function() {
         sheetRequest.usage = "widget";
         sheetRequest.ready();
-        assert.isTrue(logStub.calledWith("component_sheet_events", {"event": "ready", "usage_type": "widget"}));
+        assert.equal(logStub.args[0][0],"component_sheet_events");
+        assert.include(JSON.stringify(logStub.args[0][1]),"{\"event\":\"ready\",\"usage_type\":\"widget\",\"version\":");
       });
     });
 


### PR DESCRIPTION
- Using `rise-logger` and logging usage from `ready()` lifecycle.
- Adding `usage` property to allow for a Widget to set a value of "widget"
- Added unit tests
