### PR TITLE
Only requesting data if data ping has been received

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],
@@ -21,7 +21,7 @@
   "dependencies": {
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
-    "rise-data": "https://github.com/Rise-Vision/rise-data.git#1.0.0",
+    "rise-data": "https://github.com/Rise-Vision/rise-data.git#1.1.0",
     "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.0",
     "underscore": "~1.8.2",
     "moment": "^2.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Rise Vision web component for retrieving Google Sheet data",
   "scripts": {
     "test": "gulp test",

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -76,7 +76,7 @@ the values that can be provided in this attribute and their impact, see [Google 
 </dom-module>
 
 <!-- build:version -->
-<script>var sheetVersion = "2.3.0";</script>
+<script>var sheetVersion = "2.4.1";</script>
 <!-- endbuild -->
 
 <script>
@@ -179,6 +179,10 @@ the values that can be provided in this attribute and their impact, see [Google 
       _refreshPending: false,
 
       _initialGo: true,
+
+      _dataPingReceived: false,
+
+      _requestWaiting: false,
 
       // Element Behavior
 
@@ -361,6 +365,15 @@ the values that can be provided in this attribute and their impact, see [Google 
 
       },
 
+      _onDataPingReceived: function() {
+        this._dataPingReceived = true;
+
+        if (this._requestWaiting) {
+          this._requestWaiting = false;
+          this.go();
+        }
+      },
+
       _getParams: function() {
         var params = {};
 
@@ -444,7 +457,13 @@ the values that can be provided in this attribute and their impact, see [Google 
       ready: function() {
         var params = {
           event: "ready"
-        };
+        },
+          self = this;
+
+        // listen for data ping received
+        this.$.data.addEventListener("rise-data-ping-received", function() {
+          self._onDataPingReceived();
+        });
 
         // only include usage_type if it's a valid usage value
         if (this._isValidUsage(this.usage)) {
@@ -469,9 +488,13 @@ the values that can be provided in this attribute and their impact, see [Google 
           return;
         }
 
-        this.$.data.getItem(this._getDataKey(), function (cachedData) {
-          self._process(cachedData);
-        });
+        if (this._dataPingReceived) {
+          this.$.data.getItem(this._getDataKey(), function (cachedData) {
+            self._process(cachedData);
+          });
+        } else {
+          this._requestWaiting = true;
+        }
 
       }
 

--- a/test/rise-google-sheet-integration.html
+++ b/test/rise-google-sheet-integration.html
@@ -52,6 +52,8 @@
         sinon.stub(sheetRequest.$.data, "getItem", function(key, cb) {
           cb(null);
         });
+
+        sheetRequest._onDataPingReceived();
       });
 
       suiteTeardown(function() {
@@ -155,6 +157,8 @@
         sinon.stub(sheetRequest.$.data, "getItem", function(key, cb) {
           return cb({data: {results: sheetData.values}, timestamp: ""});
         });
+
+        sheetRequest._onDataPingReceived();
       });
 
       suiteTeardown(function() {

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -189,6 +189,37 @@
 
     });
 
+    suite("_onDataPingReceived", function() {
+
+      setup(function() {
+        sheetRequest._dataPingReceived = false;
+      });
+
+      suiteTeardown(function() {
+        sheetRequest._dataPingReceived = false;
+        sheetRequest._requestWaiting = false;
+      });
+
+      test("should set value", function() {
+        sheetRequest._onDataPingReceived();
+
+        assert.isTrue(sheetRequest._dataPingReceived);
+      });
+
+      test("should call go() if request waiting", function() {
+        var goStub = sinon.stub(sheetRequest, "go");
+
+        sheetRequest._requestWaiting = true;
+        sheetRequest._onDataPingReceived();
+
+        assert.isFalse(sheetRequest._requestWaiting);
+        assert.isTrue(goStub.calledOnce);
+
+        goStub.restore();
+      });
+
+    });
+
     suite("_prepareResponse", function() {
       test("should return an Array of values", function() {
         var response = sheetRequest._prepareResponse(sheetData);
@@ -366,6 +397,8 @@
         sheetRequest.key = "abc123";
         sheetRequest.apikey = "def456";
         sheetRequest.sheet = "Sheet1";
+        sheetRequest._dataPingReceived = false;
+        sheetRequest._requestWaiting = false;
         sheetRequest.$.data.getItem.restore();
       });
 
@@ -392,9 +425,17 @@
         assert.equal(getStub.callCount, 0);
       });
 
+      test("should not make call to generate request if data ping has not been received", function () {
+        sheetRequest.go();
+
+        assert.equal(getStub.callCount, 0);
+        assert.isTrue(sheetRequest._requestWaiting);
+      });
+
       test("should get cached data and call _process with provided data", function () {
         var processStub = sinon.stub(sheetRequest, "_process");
 
+        sheetRequest._dataPingReceived = true;
         sheetRequest.go();
 
         assert.isTrue(getStub.calledOnce);
@@ -406,6 +447,7 @@
       test("should not execute further request when there is one pending a response", function() {
         var requestStub = sinon.stub(sheetRequest.$.sheet, "generateRequest", function (){});
 
+        sheetRequest._dataPingReceived = true;
         sheetRequest.go();
         sheetRequest.go();
         sheetRequest.go();


### PR DESCRIPTION
- Listening for `rise-data-ping-received` event from `rise-data`
- Conditionally processing a request if data ping has been received, flagging that a request is waiting if it hasn't
- Unit tests added and integration tests revised
- Minor patch version bump