### PR TITLE
Changed component to return the cached data when there is a error on …

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "Rise Vision web component for retrieving Google Sheet data",
   "scripts": {
     "test": "gulp test",

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -76,7 +76,7 @@ the values that can be provided in this attribute and their impact, see [Google 
 </dom-module>
 
 <!-- build:version -->
-<script>var sheetVersion = "2.4.6";</script>
+<script>var sheetVersion = "2.4.7";</script>
 <!-- endbuild -->
 
 <script>
@@ -212,7 +212,7 @@ the values that can be provided in this attribute and their impact, see [Google 
       },
 
       _getDataKey: function() {
-        return DATAKEY_BASE_NAME + "_" + this.key + "_" + this.sheet +
+        return DATAKEY_BASE_NAME + "_" + this.key + "_" + encodeURIComponent( this.sheet ) +
           ( this.range === "" ? "" : "_" + this.range );
       },
 
@@ -292,17 +292,15 @@ the values that can be provided in this attribute and their impact, see [Google 
         this._startTimer();
       },
 
-      _handleNoNetwork: function( resp ) {
+      _handleErrorsWithCachedData: function( resp ) {
         var self = this;
 
         this.$.data.getItem( this._getDataKey(), function( cachedData ) {
           if ( cachedData ) {
             self._setResults( cachedData.data.results );
-
-            self.fire( "rise-google-sheet-response", cachedData.data );
-          } else {
-            self.fire( "rise-google-sheet-error", resp );
+            resp = Object.assign( resp, cachedData.data );
           }
+          self.fire( "rise-google-sheet-error", resp );
         } );
 
         this._requestPending = false;
@@ -316,24 +314,11 @@ the values that can be provided in this attribute and their impact, see [Google 
         if ( resp.request ) {
           /* eslint-disable indent */
           switch ( resp.request.status ) {
-            case 0:
-              this._handleNoNetwork( resp );
-              break;
             case 429:
               this._handleQuotaExceeded();
               break;
             default:
-              // reset the value of cells
-              this._setResults( [] );
-
-              // delete cached data
-              this.$.data.deleteItem( this._getDataKey() );
-
-              this.fire( "rise-google-sheet-error", resp );
-
-              this._requestPending = false;
-              this._startTimer();
-
+              this._handleErrorsWithCachedData( resp );
               break;
           }
           /* eslint-enable indent */

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -312,7 +312,7 @@ the values that can be provided in this attribute and their impact, see [Google 
         e.stopPropagation();
 
         if ( resp.request ) {
-          if ( resp.request.status === 429) {
+          if ( resp.request.status === 429 ) {
             this._handleQuotaExceeded();
           } else {
             this._handleErrorsWithCachedData( resp );

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -312,18 +312,12 @@ the values that can be provided in this attribute and their impact, see [Google 
         e.stopPropagation();
 
         if ( resp.request ) {
-          /* eslint-disable indent */
-          switch ( resp.request.status ) {
-            case 429:
-              this._handleQuotaExceeded();
-              break;
-            default:
-              this._handleErrorsWithCachedData( resp );
-              break;
+          if ( resp.request.status === 429) {
+            this._handleQuotaExceeded();
+          } else {
+            this._handleErrorsWithCachedData( resp );
           }
-          /* eslint-enable indent */
         }
-
       },
 
       _onSheetResponse: function( e, resp ) {

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -68,13 +68,13 @@
       } );
 
       test( "should return correct data key using unique and required sheet key and name", function() {
-        assert.equal( sheetRequest._getDataKey(), "risesheet_abc123_Sheet/1" );
+        assert.equal( sheetRequest._getDataKey(), "risesheet_abc123_Sheet%2F1" );
       } );
 
       test( "should return correct data key using unique sheet key and range", function() {
         sheetRequest.range = "A1:C3";
 
-        assert.equal( sheetRequest._getDataKey(), "risesheet_abc123_Sheet/1_A1:C3" );
+        assert.equal( sheetRequest._getDataKey(), "risesheet_abc123_Sheet%2F1_A1:C3" );
       } );
 
     } );
@@ -84,21 +84,19 @@
         "stopPropagation": function() {}
       };
 
-      test( "should fire rise-google-sheet-error when handling <iron-ajax> request error ", function( done ) {
-        listener = function() {
-          responded = true;
+      test( "should call _handleErrorsWithCachedData when handling <iron-ajax> request error ", function( ) {
+        var _handleErrorsWithCachedDataStub = sinon.stub( sheetRequest, "_handleErrorsWithCachedData" );
 
-          sheetRequest.removeEventListener( "rise-google-sheet-error", listener );
-        };
-
-        sheetRequest.addEventListener( "rise-google-sheet-error", listener );
         sheetRequest._onSheetError( e, errorData );
-        assert.isTrue( responded );
-        done();
+
+        assert.isTrue( _handleErrorsWithCachedDataStub.calledOnce );
+
+        sheetRequest._handleErrorsWithCachedData.restore();
+
       } );
 
-      test( "should call _handleNoNetwork if request status is 0", function() {
-        var noNetworkStub = sinon.stub( sheetRequest, "_handleNoNetwork" );
+      test( "should call _handleErrorsWithCachedData if request status is 0", function() {
+        var _handleErrorsWithCachedDataStub = sinon.stub( sheetRequest, "_handleErrorsWithCachedData" );
 
         sheetRequest._onSheetError( e, {
           "request": {
@@ -106,9 +104,9 @@
           }
         } );
 
-        assert.isTrue( noNetworkStub.calledOnce );
+        assert.isTrue( _handleErrorsWithCachedDataStub.calledOnce );
 
-        sheetRequest._handleNoNetwork.restore();
+        sheetRequest._handleErrorsWithCachedData.restore();
       } );
 
       test( "should call _handleQuotaExceeded if request status is 429", function() {
@@ -125,25 +123,30 @@
         sheetRequest._handleQuotaExceeded.restore();
       } );
 
-      test( "should call deleteItem on data component", function() {
-        var spy = sinon.spy( sheetRequest.$.data, "deleteItem" );
+      test( "should start a refresh timer after calling _handleErrorsWithCachedData", function(done) {
+        var getStub = sinon.stub( sheetRequest.$.data, "getItem", function( key, cb ) {
+          return cb( { data: { results: sheetData.values }, timestamp: "" } );
+        } );
 
-        sheetRequest._onSheetError( e, errorData );
-
-        assert.isTrue( spy.calledOnce );
-
-        sheetRequest.$.data.deleteItem.restore();
-      } );
-
-      test( "should start a refresh timer after firing rise-google-sheet-error", function() {
         var timerStub = sinon.stub( sheetRequest, "_startTimer" );
+        var logStub = sinon.stub( sheetRequest.$.logger, "log" );
+
+        listener = function() {
+          setTimeout(function() {
+            assert( timerStub.calledOnce );
+            sheetRequest._startTimer.restore();
+            getStub.restore();
+            logStub.restore();
+            sheetRequest.removeEventListener( "rise-google-sheet-error", listener );
+            done();
+          },100);
+        };
+
+        sheetRequest.addEventListener( "rise-google-sheet-error", listener );
 
         sheetRequest._onSheetError( e, errorData );
-        assert( timerStub.calledOnce );
-
-        sheetRequest._startTimer.restore();
+        clock.tick(100);
       } );
-
     } );
 
     suite( "_onSheetResponse", function() {
@@ -488,7 +491,7 @@
 
     } );
 
-    suite( "_handleNoNetwork", function() {
+    suite( "_handleErrorsWithCachedData", function() {
       var resp = {
           "error": {},
           "request": {
@@ -503,7 +506,7 @@
         getStub.restore();
       } );
 
-      test( "should fire rise-google-sheet-response when cached data exists", function( done ) {
+      test( "should fire rise-google-sheet-error when cached data exists", function( done ) {
         getStub = sinon.stub( sheetRequest.$.data, "getItem", function( key, cb ) {
           return cb( { data: { results: sheetData.values }, timestamp: "" } );
         } );
@@ -514,11 +517,11 @@
           assert.property( response.detail, "results", "detail.results property exists" );
           assert.deepEqual( response.detail.results, sheetData.values );
 
-          sheetRequest.removeEventListener( "rise-google-sheet-response", listener );
+          sheetRequest.removeEventListener( "rise-google-sheet-error", listener );
         };
 
-        sheetRequest.addEventListener( "rise-google-sheet-response", listener );
-        sheetRequest._handleNoNetwork( resp );
+        sheetRequest.addEventListener( "rise-google-sheet-error", listener );
+        sheetRequest._handleErrorsWithCachedData( resp );
 
         assert.isTrue( responded );
 
@@ -539,7 +542,7 @@
         };
 
         sheetRequest.addEventListener( "rise-google-sheet-error", listener );
-        sheetRequest._handleNoNetwork( resp );
+        sheetRequest._handleErrorsWithCachedData( resp );
 
         assert.isTrue( responded );
 

--- a/test/rise-google-sheet-unit.html
+++ b/test/rise-google-sheet-unit.html
@@ -123,29 +123,28 @@
         sheetRequest._handleQuotaExceeded.restore();
       } );
 
-      test( "should start a refresh timer after calling _handleErrorsWithCachedData", function(done) {
+      test( "should start a refresh timer after calling _handleErrorsWithCachedData", function( done ) {
         var getStub = sinon.stub( sheetRequest.$.data, "getItem", function( key, cb ) {
-          return cb( { data: { results: sheetData.values }, timestamp: "" } );
-        } );
-
-        var timerStub = sinon.stub( sheetRequest, "_startTimer" );
-        var logStub = sinon.stub( sheetRequest.$.logger, "log" );
+            return cb( { data: { results: sheetData.values }, timestamp: "" } );
+          } ),
+          timerStub = sinon.stub( sheetRequest, "_startTimer" ),
+          logStub = sinon.stub( sheetRequest.$.logger, "log" );
 
         listener = function() {
-          setTimeout(function() {
+          setTimeout( function() {
             assert( timerStub.calledOnce );
             sheetRequest._startTimer.restore();
             getStub.restore();
             logStub.restore();
             sheetRequest.removeEventListener( "rise-google-sheet-error", listener );
             done();
-          },100);
+          }, 100 );
         };
 
         sheetRequest.addEventListener( "rise-google-sheet-error", listener );
 
         sheetRequest._onSheetError( e, errorData );
-        clock.tick(100);
+        clock.tick( 100 );
       } );
     } );
 


### PR DESCRIPTION
…getting data

Fixed a small thing on the data key, now it encodes the sheet name

I found a better way to handle the scenario where there is an error and cache data. It will send both with the fire event so on the widget it can log the error at the same time as showing the cached data. Please review.

cheers
