### PR TITLE
Upgrade rise-logger and rise-data dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],
@@ -21,8 +21,8 @@
   "dependencies": {
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
-    "rise-data": "https://github.com/Rise-Vision/rise-data.git#1.3.9",
-    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.11",
+    "rise-data": "https://github.com/Rise-Vision/rise-data.git#2.0.2",
+    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.12",
     "underscore": "~1.8.2",
     "moment": "^2.14.0"
   },

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: stable
+    version: 6.9.1
 dependencies:
   pre:
     # latest stable chrome

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-sheet",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "description": "Rise Vision web component for retrieving Google Sheet data",
   "scripts": {
     "test": "gulp test",
@@ -39,6 +39,6 @@
     "gulp-html-replace": "~1.6.1",
     "run-sequence": "~1.1.0",
     "web-component-tester": "*",
-    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
+    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#v1.8.1"
   }
 }

--- a/rise-google-sheet.html
+++ b/rise-google-sheet.html
@@ -76,7 +76,7 @@ the values that can be provided in this attribute and their impact, see [Google 
 </dom-module>
 
 <!-- build:version -->
-<script>var sheetVersion = "2.4.11";</script>
+<script>var sheetVersion = "2.4.12";</script>
 <!-- endbuild -->
 
 <script>
@@ -524,6 +524,10 @@ the values that can be provided in this attribute and their impact, see [Google 
 
         // listen for data ping received
         this.$.data.addEventListener( "rise-data-ping-received", function() {
+          /* this component doesn't require it (yet), but this event provides the following (via rise-data 2.x.x):
+             event.detail.isCacheRunning & event.detail.baseCacheUrl
+             See rise-financial usage - https://goo.gl/suHb4y
+          */
           self._onDataPingReceived();
         } );
 


### PR DESCRIPTION
- This is to fix the issue with Spreadsheet widget running in Preview on Chrome 67 whereby `attached` in the child components `rise-logger` and `rise-data` are not firing. 